### PR TITLE
Ignore account names

### DIFF
--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -34,9 +34,11 @@ class ECImporter(importer.ImporterProtocol):
         self.numeric_locale = numeric_locale
         self.file_encoding = file_encoding
 
-        self._expected_header_regex = re.compile(r"^\"Kontonummer:\";\"" +
-                re.escape(re.sub(r"\s+", "", iban, flags=re.UNICODE)) + "\s",
-                re.IGNORECASE)
+        self._expected_header_regex = re.compile(
+            r"^\"Kontonummer:\";\"" +
+            re.escape(re.sub(r"\s+", "", iban, flags=re.UNICODE)) + "\s",
+            re.IGNORECASE
+        )
         self._date_from = None
         self._date_to = None
         self._balance = None

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -27,6 +27,7 @@ class ECImporterTestCase(TestCase):
         super(ECImporterTestCase, self).setUp()
 
         self.iban = 'DE99999999999999999999'
+        self.formatted_iban = 'DE99 9999 9999 9999 9999 99'
         self.filename = path_for_temp_file('{}.csv'.format(self.iban))
 
     def tearDown(self):
@@ -58,6 +59,23 @@ class ECImporterTestCase(TestCase):
         with open(self.filename, 'wb') as fd:
             fd.write(_format('''
                 "Kontonummer:";"{iban} / My Custom Named Account";
+
+                "Von:";"01.01.2018";
+                "Bis:";"31.01.2018";
+                "Kontostand vom 31.01.2017:";"5.000,01 EUR";
+
+                {header};
+            ''', dict(iban=self.iban, header=HEADER)))
+
+        with open(self.filename) as fd:
+            self.assertTrue(importer.identify(fd))
+
+    def test_identify_with_formatted_iban(self):
+        importer = ECImporter(self.formatted_iban, 'Assets:DKB:EC')
+
+        with open(self.filename, 'wb') as fd:
+            fd.write(_format('''
+                "Kontonummer:";"{iban} / Girokonto";
 
                 "Von:";"01.01.2018";
                 "Bis:";"31.01.2018";

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -70,6 +70,23 @@ class ECImporterTestCase(TestCase):
         with open(self.filename) as fd:
             self.assertTrue(importer.identify(fd))
 
+    def test_identify_with_exotic_account_name(self):
+        importer = ECImporter(self.iban, 'Assets:DKB:EC')
+
+        with open(self.filename, 'wb') as fd:
+            fd.write(_format('''
+                "Kontonummer:";"{iban} / Girökóntô, Γιροκοντώ, 預金, حساب البنك";
+
+                "Von:";"01.01.2018";
+                "Bis:";"31.01.2018";
+                "Kontostand vom 31.01.2017:";"5.000,01 EUR";
+
+                {header};
+            ''', dict(iban=self.iban, header=HEADER)))
+
+        with open(self.filename) as fd:
+            self.assertTrue(importer.identify(fd))
+
     def test_identify_with_formatted_iban(self):
         importer = ECImporter(self.formatted_iban, 'Assets:DKB:EC')
 

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -52,6 +52,23 @@ class ECImporterTestCase(TestCase):
         with open(self.filename) as fd:
             self.assertTrue(importer.identify(fd))
 
+    def test_identify_with_nonstandard_account_name(self):
+        importer = ECImporter(self.iban, 'Assets:DKB:EC')
+
+        with open(self.filename, 'wb') as fd:
+            fd.write(_format('''
+                "Kontonummer:";"{iban} / My Custom Named Account";
+
+                "Von:";"01.01.2018";
+                "Bis:";"31.01.2018";
+                "Kontostand vom 31.01.2017:";"5.000,01 EUR";
+
+                {header};
+            ''', dict(iban=self.iban, header=HEADER)))
+
+        with open(self.filename) as fd:
+            self.assertTrue(importer.identify(fd))
+
     def test_identify_invalid_iban(self):
         other_iban = 'DE00000000000000000000'
 


### PR DESCRIPTION
Excellent project, many thanks for getting started on this!

I use custom account names within DKB such that my exports don't start with

> "Kontonummer:";"DE12345678912345678912 / Girokonto";

but instead with something like

> "Kontonummer:";"DE12345678912345678912 / Niels - Giro";

or

> "Kontonummer:";"DE12345678912345678912 / Joint - Giro";

These files were previously impossible to import as `ECImporter` had a hardcoded expectation on the account name `Girokonto`.

This PR disregards the account name entirely, instead asserting on the IBAN only. I have also changed that assertion to now be case-insensitive and ignore spaces so that one can use the more human-readable formatting (e.g `DE12 3456 7891 2345 6789 12`) in their bean-extract config.

Note that the format with spacing also happens to be the one DKB shows on the online banking landing page so that the config is now copy-paste friendly.