### PR TITLE
Differentiate between payee and narration

### DIFF
--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -120,7 +120,7 @@ class ECImporter(importer.ImporterProtocol):
                     else:
                         description = '{} {}'.format(
                             line['Buchungstext'],
-                            line['Auftraggeber / Begünstigter']
+                            line['Verwendungszweck']
                         )
 
                         postings = [
@@ -129,9 +129,12 @@ class ECImporter(importer.ImporterProtocol):
                         ]
 
                         entries.append(
-                            data.Transaction(meta, date, self.FLAG, None,
-                                             description, data.EMPTY_SET,
-                                             data.EMPTY_SET, postings)
+                            data.Transaction(
+                                meta, date, self.FLAG,
+                                line['Auftraggeber / Begünstigter'],
+                                description, data.EMPTY_SET, data.EMPTY_SET,
+                                postings
+                            )
                         )
 
             return entries

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -161,6 +161,9 @@ class ECImporterTestCase(TestCase):
 
         self.assertEqual(len(transactions), 1)
         self.assertEqual(transactions[0].date, datetime.date(2018, 1, 16))
+        self.assertEqual(transactions[0].payee, 'REWE Filialen Voll')
+        self.assertEqual(transactions[0].narration,
+                         'Lastschrift REWE SAGT DANKE.')
 
         self.assertEqual(len(transactions[0].postings), 1)
         self.assertEqual(transactions[0].postings[0].account, 'Assets:DKB:EC')


### PR DESCRIPTION
This may be a controversial suggestion, but I think it would be very useful to (a) explicitly extract the payee (_Auftraggeber / Begünstigter_) and (b) actually extract (i.e. not discard) the transaction purpose (_Verwendungszweck_).

Given an input file

```csv
"Buchungstag";"Wertstellung";"Buchungstext";"Auftraggeber / Begünstigter";"Verwendungszweck";"Kontonummer";"BLZ";"Betrag (EUR)";"Gläubiger-ID";"Mandatsreferenz";"Kundenreferenz";
"16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
```

this PR turns the previous transaction

```
2018-01-16 * "Lastschrift REWE Filialen Voll"
```

into

```
2018-01-16 * "REWE Filialen Voll" "Lastschrift REWE SAGT DANKE."
```