### PR TITLE
Implement a file_name() returning "from-date - to-date" for bean-file

### DIFF
--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -46,6 +46,11 @@ class ECImporter(importer.ImporterProtocol):
     def file_account(self, _):
         return self.account
 
+    def file_name(self, file_):
+        self.extract(file_)
+        return self._date_from.strftime("%Y-%m-%d") + ' - ' + \
+            self._date_to.strftime("%Y-%m-%d")
+
     def identify(self, file_):
         with open(file_.name, encoding=self.file_encoding) as fd:
             line = fd.readline().strip()

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -219,3 +219,22 @@ class ECImporterTestCase(TestCase):
         self.assertEqual(transactions[0].date, datetime.date(2018, 1, 20))
         self.assertEqual(transactions[0].amount,
                          Amount(Decimal('2500.01'), currency='EUR'))
+
+    def test_file_name(self):
+        with open(self.filename, 'wb') as fd:
+            fd.write(_format('''
+                "Kontonummer:";"{iban} / Girokonto";
+
+                "Von:";"01.01.2018";
+                "Bis:";"31.01.2018";
+                "Kontostand vom 31.01.2017:";"5.000,01 EUR";
+
+                {header};
+                "20.01.2018";"";"";"";"Tagessaldo";"";"";"2.500,01";
+            ''', dict(iban=self.iban, header=HEADER)))  # NOQA
+        importer = ECImporter(self.iban, 'Assets:DKB:EC',
+                              file_encoding='utf-8')
+
+        with open(self.filename) as fd:
+            importer.extract(fd)
+            self.assertEqual(importer.file_name(fd), '2018-01-01 - 2018-01-31')


### PR DESCRIPTION
When using `bean-file`, by default the file is named after the current day. Frequently, however, one probably imports older statements. This PR leads to `bean-file` naming files "Start-Date - End-Date", such as "2018-01-01 - 2018-01-31" for a statement covering Jan 1st to 31st 2018.