### PR TITLE
Implement file_date returning the closing date of the statement

### DIFF
--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -46,6 +46,10 @@ class ECImporter(importer.ImporterProtocol):
     def file_account(self, _):
         return self.account
 
+    def file_date(self, file_):
+        self.extract(file_)
+        return self._date_to
+
     def identify(self, file_):
         with open(file_.name, encoding=self.file_encoding) as fd:
             line = fd.readline().strip()

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -219,3 +219,22 @@ class ECImporterTestCase(TestCase):
         self.assertEqual(transactions[0].date, datetime.date(2018, 1, 20))
         self.assertEqual(transactions[0].amount,
                          Amount(Decimal('2500.01'), currency='EUR'))
+
+    def test_file_date(self):
+        with open(self.filename, 'wb') as fd:
+            fd.write(_format('''
+                "Kontonummer:";"{iban} / Girokonto";
+
+                "Von:";"01.01.2018";
+                "Bis:";"31.01.2018";
+                "Kontostand vom 31.01.2017:";"5.000,01 EUR";
+
+                {header};
+                "20.01.2018";"";"";"";"Tagessaldo";"";"";"2.500,01";
+            ''', dict(iban=self.iban, header=HEADER)))  # NOQA
+        importer = ECImporter(self.iban, 'Assets:DKB:EC',
+                              file_encoding='utf-8')
+
+        with open(self.filename) as fd:
+            self.assertEqual(importer.file_date(fd),
+                             datetime.date(2018, 1, 31))


### PR DESCRIPTION
When using `bean-file`, by default the current date is prepended to the file name. Frequently, however, one probably imports older statements. This PR implements `file_date()` so that file names are prefixed by the closing date of the account statement, rather than the current (at the time of `bean-file` invocation) date.