### PR TITLE
Bugfix (locale) and change of description to payee for credit cards.

### DIFF
--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -129,7 +129,8 @@ class CreditImporter(importer.ImporterProtocol):
                     date = datetime.strptime(
                         line['Belegdatum'], '%d.%m.%Y').date()
 
-                    description = line['Beschreibung']
+                    payee = line['Beschreibung']
+                    description = ""
 
                     postings = [
                         data.Posting(self.account, amount, None, None, None,
@@ -137,7 +138,7 @@ class CreditImporter(importer.ImporterProtocol):
                     ]
 
                     entries.append(
-                        data.Transaction(meta, date, self.FLAG, None,
+                        data.Transaction(meta, date, self.FLAG, payee,
                                          description, data.EMPTY_SET,
                                          data.EMPTY_SET, postings)
                     )

--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -93,9 +93,10 @@ class CreditImporter(importer.ImporterProtocol):
                         self._date_to = datetime.strptime(
                             value, '%d.%m.%Y').date()
                     elif key.startswith('Saldo'):
-                        self._balance = Amount(
-                            locale.atof(value.rstrip(' EUR'), Decimal),
-                            self.currency)
+                        with change_locale(locale.LC_NUMERIC, 'en_US.UTF-8'):
+                            self._balance = Amount(
+                                locale.atof(value.rstrip(' EUR'), Decimal),
+                                self.currency)
                         closing_balance_index = line_index
                     elif key.startswith('Datum'):
                         self._date_balance = datetime.strptime(

--- a/tests/test_credit.py
+++ b/tests/test_credit.py
@@ -41,7 +41,7 @@ class CreditImporterTestCase(TestCase):
         common = '''
             "Von:";"01.01.2018";
             "Bis:";"31.01.2018";
-            "Saldo:";"5.000,01 EUR";
+            "Saldo:";"5000.01 EUR";
             "Datum:";"15.02.2018";
         '''
 
@@ -78,7 +78,7 @@ class CreditImporterTestCase(TestCase):
 
                 "Von:";"01.01.2018";
                 "Bis:";"31.01.2018";
-                "Saldo:";"5.000,01 EUR";
+                "Saldo:";"5000.01 EUR";
                 "Datum:";"15.02.2018";
 
                 {header};
@@ -96,7 +96,7 @@ class CreditImporterTestCase(TestCase):
 
                 "Von:";"01.01.2018";
                 "Bis:";"31.01.2018";
-                "Saldo:";"5.000,01 EUR";
+                "Saldo:";"5000.01 EUR";
                 "Datum:";"15.02.2018";
 
                 {header};
@@ -116,7 +116,7 @@ class CreditImporterTestCase(TestCase):
 
                 "Von:";"01.01.2018";
                 "Bis:";"31.01.2018";
-                "Saldo:";"5.000,01 EUR";
+                "Saldo:";"5000.01 EUR";
                 "Datum:";"15.02.2018";
 
                 {header};
@@ -138,7 +138,7 @@ class CreditImporterTestCase(TestCase):
 
                 "Von:";"01.01.2018";
                 "Bis:";"31.01.2018";
-                "Saldo:";"5.000,01 EUR";
+                "Saldo:";"5000.01 EUR";
                 "Datum:";"15.02.2018";
 
                 {header};
@@ -168,7 +168,7 @@ class CreditImporterTestCase(TestCase):
 
                 "Von:";"01.01.2018";
                 "Bis:";"31.01.2018";
-                "Saldo:";"5.000,01 EUR";
+                "Saldo:";"5000.01 EUR";
                 "Datum:";"15.02.2018";
 
                 {header};
@@ -197,7 +197,7 @@ class CreditImporterTestCase(TestCase):
 
                 "Von:";"01.01.2018";
                 "Bis:";"31.01.2018";
-                "Saldo:";"5.000,01 EUR";
+                "Saldo:";"5000.01 EUR";
                 "Datum:";"15.02.2018";
 
                 {header};


### PR DESCRIPTION
This fixes a bug in the previous PR, regarding the locale of the "Saldo" field for credit cards. There, the format in the csv file uses "5001.01 EUR" (the US notation) and not "5.001,01 EUR" (the German notation) like the remainder of the file.

For credit cards, the csv file has a field called "Bescheibung" ('description') and gives no payee. The content of the field, however, is in my cases always the payee. Therefore, this PR sets the payee and leaves the description empty. This also matches my personal workflow, where I require an empty description field in Fava.