### PR TITLE
fixes bug: ec for "Tagessaldo" with empty balance and adds test

### DIFF
--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -114,16 +114,20 @@ class ECImporter(importer.ImporterProtocol):
                 for line in reader:
                     meta = data.new_metadata(file_.name, line_index)
 
-                    amount = Amount(locale.atof(line['Betrag (EUR)'], Decimal),
-                                    self.currency)
+                    amount = None
+                    if line['Betrag (EUR)']:
+                        amount = Amount(locale.atof(line['Betrag (EUR)'],
+                                        Decimal),
+                                        self.currency)
                     date = datetime.strptime(
                         line['Buchungstag'], '%d.%m.%Y').date()
 
                     if line['Verwendungszweck'] == 'Tagessaldo':
-                        entries.append(
-                            data.Balance(meta, date, self.account, amount,
-                                         None, None)
-                        )
+                        if amount:
+                            entries.append(
+                                data.Balance(meta, date, self.account, amount,
+                                             None, None)
+                            )
                     else:
                         description = '{} {}'.format(
                             line['Buchungstext'],

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -249,6 +249,10 @@ class ECImporterTestCase(TestCase):
             transactions = importer.extract(fd)
 
         self.assertEqual(len(transactions), 1)
+        self.assertTrue(isinstance(transactions[0], Balance))
+        self.assertEqual(transactions[0].date, datetime.date(2018, 1, 31))
+        self.assertEqual(transactions[0].amount,
+                         Amount(Decimal('5000.01'), currency='EUR'))
 
     def test_file_date(self):
         with open(self.filename, 'wb') as fd:

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -230,6 +230,26 @@ class ECImporterTestCase(TestCase):
         self.assertEqual(transactions[0].amount,
                          Amount(Decimal('2500.01'), currency='EUR'))
 
+    def test_tagessaldo_with_empty_balance_does_not_crash(self):
+        with open(self.filename, 'wb') as fd:
+            fd.write(_format('''
+                "Kontonummer:";"{iban} / Girokonto";
+
+                "Von:";"01.01.2018";
+                "Bis:";"31.01.2018";
+                "Kontostand vom 31.01.2018:";"5.000,01 EUR";
+
+                {header};
+                "20.01.2018";"";"";"";"Tagessaldo";"";"";"";
+            ''', dict(iban=self.iban, header=HEADER)))  # NOQA
+        importer = ECImporter(self.iban, 'Assets:DKB:EC',
+                              file_encoding='utf-8')
+
+        with open(self.filename) as fd:
+            transactions = importer.extract(fd)
+
+        self.assertEqual(len(transactions), 1)
+
     def test_file_date(self):
         with open(self.filename, 'wb') as fd:
             fd.write(_format('''


### PR DESCRIPTION
The csv file sometimes has a line with "Tagessaldo" with an empty balance in the first line of the csv data block.