### PR TITLE
Add optional parameter existing_entries to extract()

### DIFF
--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -76,7 +76,7 @@ class CreditImporter(importer.ImporterProtocol):
 
         return self.is_valid_header(line)
 
-    def extract(self, file_):
+    def extract(self, file_, existing_entries=None):
         entries = []
         line_index = 0
         closing_balance_index = -1

--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -57,7 +57,7 @@ class ECImporter(importer.ImporterProtocol):
 
         return self._expected_header_regex.match(line)
 
-    def extract(self, file_):
+    def extract(self, file_, existing_entries=None):
         entries = []
         line_index = 0
         closing_balance_index = -1


### PR DESCRIPTION
beancount/ingest/importer.py defines extract() as:

    def extract(self, file, existing_entries=None):
...
          existing_entries: An optional list of existing directives loaded from
            the ledger which is intended to contain the extracted entries. This
            is only provided if the user provides them via a flag in the
            extractor program.

smart_importer's hooks pass existing_entries to extract() and the DKB
importer fails because it doesn't recognize this optional argument.