### PR TITLE
feat: option to add transaction code as metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,41 @@ line to extract the transactions and pipe all of them into your Beancount file.
 $ bean-extract /path/to/config.py transaction.csv >> you.beancount
 ```
 
+### Transaction Codes as Meta Tags
+
+By default, the ECImporter prepends the transaction code ("Buchungstext") to the transaction description. To achieve shorter descriptions and use meta tags to query for certain transaction codes, the importer may be configured to store the transaction code in a user provided meta tag.
+
+The following configuration instructs the importer to use a meta tag `code` to store transaction codes:
+
+```python
+...
+CONFIG = [
+    ECImporter(
+        IBAN_NUMBER,
+        'Assets:DKB:EC',
+        currency='EUR',
+        meta_code='code',
+    ),
+...
+
+```
+
+This is how an example transaction looks without the option:
+
+```beancount
+2021-03-01 * "Kartenzahlung" "XY Supermarket"
+    Assets:DKB:EC                        -133.72 EUR
+```
+
+And this is the resulting transaction using `meta_code='code'`
+
+```beancount
+2021-03-01 * "XY Supermarket"
+    code: Kartenzahlung
+    Assets:DKB:EC                        -133.72 EUR
+```
+
+
 ## FAQ
 
 ```sh

--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -24,7 +24,8 @@ FIELDS = (
 
 
 class ECImporter(importer.ImporterProtocol):
-    def __init__(self, iban, account, currency='EUR', file_encoding='utf-8', meta_code=None):
+    def __init__(self, iban, account, currency='EUR', file_encoding='utf-8',
+                 meta_code=None):
         self.account = account
         self.currency = currency
         self.file_encoding = file_encoding

--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -24,10 +24,11 @@ FIELDS = (
 
 
 class ECImporter(importer.ImporterProtocol):
-    def __init__(self, iban, account, currency='EUR', file_encoding='utf-8'):
+    def __init__(self, iban, account, currency='EUR', file_encoding='utf-8', meta_code=None):
         self.account = account
         self.currency = currency
         self.file_encoding = file_encoding
+        self.meta_code = meta_code
 
         self._expected_header_regex = re.compile(
             r'^"Kontonummer:";"'
@@ -147,10 +148,18 @@ class ECImporter(importer.ImporterProtocol):
                             )
                         )
                 else:
-                    description = '{} {}'.format(
-                        line['Buchungstext'],
-                        line['Verwendungszweck'] or line['Kontonummer'],
-                    )
+                    verwendungszweck = line['Verwendungszweck'] or \
+                        line['Kontonummer']
+                    buchungstext = line['Buchungstext']
+
+                    if self.meta_code:
+                        meta[self.meta_code] = buchungstext
+                        description = verwendungszweck
+                    else:
+                        description = '{} {}'.format(
+                            buchungstext,
+                            verwendungszweck,
+                        )
 
                     postings = [
                         data.Posting(

--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -24,8 +24,14 @@ FIELDS = (
 
 
 class ECImporter(importer.ImporterProtocol):
-    def __init__(self, iban, account, currency='EUR', file_encoding='utf-8',
-                 meta_code=None):
+    def __init__(
+        self,
+        iban,
+        account,
+        currency='EUR',
+        file_encoding='utf-8',
+        meta_code=None,
+    ):
         self.account = account
         self.currency = currency
         self.file_encoding = file_encoding
@@ -149,8 +155,9 @@ class ECImporter(importer.ImporterProtocol):
                             )
                         )
                 else:
-                    verwendungszweck = line['Verwendungszweck'] or \
-                        line['Kontonummer']
+                    verwendungszweck = (
+                        line['Verwendungszweck'] or line['Kontonummer']
+                    )
                     buchungstext = line['Buchungstext']
 
                     if self.meta_code:
@@ -158,8 +165,7 @@ class ECImporter(importer.ImporterProtocol):
                         description = verwendungszweck
                     else:
                         description = '{} {}'.format(
-                            buchungstext,
-                            verwendungszweck,
+                            buchungstext, verwendungszweck,
                         )
 
                     postings = [


### PR DESCRIPTION
Actually I accidentally created this PR to this repos instead of my own. But I will leave it open in case there is interest in merging it.

This PR add the argument `meta_code` to the importer's constructor. If set, the importer will add the code of a transaction  ("Buchungstext") as metadata with the key `meta_code` instead of adding it to the description. Helpful for querying with beancount later.