### PR TITLE
feat: automatic transaction categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ CONFIG = [
         meta_code='code',
     ),
 ...
-
 ```
 
 This is how an example transaction looks without the option:
@@ -105,10 +104,11 @@ This package provides the `PayeeCategorizer` implementation. It is instantiated 
 The following example configuration makes use of the `PayeeCategorizer`:
 
 ```python
-categorizer = PayeeCategorizer(
-    [{"account": "Expenses:Food:Groceries", "payees": ["^SUPERMARKET XY", "^MY DELI"]}]
-)
 ...
+categorizer = PayeeCategorizer(
+    {"Expenses:Food:Groceries": ["^SUPERMARKET XY", "^MY DELI"]}
+)
+
 CONFIG = [
     ECImporter(
         IBAN_NUMBER,
@@ -117,7 +117,6 @@ CONFIG = [
         categorizer=categorizer,
     ),
 ...
-
 ```
 
 CSV entries matching the payee regex will produce transactions such as the following:

--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ And this is the resulting transaction using `meta_code='code'`
 
 The DKB importer supports automatic categorization of transactions by a user provided configuration. Any `Categorizer` that implements the `CategorizerProtocol` can be provided to both `ECImporter` and `Creditimporter` through the main configuration file.
 
-This package provides the `PayeeCategorizer` implementation. It is instantiated with a dictionary that configures what payee will be categorized to which account. Each account may have multiple payees, where any transaction matched agains one of the payees will be categorized to the account.
+This package provides the `PayeeCategorizer` implementation. It is instantiated with a dictionary that configures what payee will be categorized to which account. Each account may have multiple payee regexes, where any transaction matched against one of the payee regexes will be categorized to the account.
 
 The following example configuration makes use of the `PayeeCategorizer`:
 
 ```python
 ...
 categorizer = PayeeCategorizer(
-    {"Expenses:Food:Groceries": ["^SUPERMARKET XY", "^MY DELI"]}
+    {"Expenses:Food:Groceries": ["^(SUPERMARKET XY|MY DELI)"]}
 )
 
 CONFIG = [
@@ -119,7 +119,7 @@ CONFIG = [
 ...
 ```
 
-CSV entries matching the payee regex will produce transactions such as the following:
+Matching CSV entries will produce transactions such as the following:
 
 ```beancount
 2021-03-01 * "SUPERMARKET XY SAGT DANKE"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,44 @@ And this is the resulting transaction using `meta_code='code'`
     Assets:DKB:EC                        -133.72 EUR
 ```
 
+### Automatic Categorization
+
+The DKB importer supports automatic categorization of transactions by a user provided configuration. Any `Categorizer` that implements the `CategorizerProtocol` can be provided to both `ECImporter` and `Creditimporter` through the main configuration file.
+
+This package provides the `PayeeCategorizer` implementation. It is instantiated with a dictionary that configures what payee will be categorized to which account. Each account may have multiple payees, where any transaction matched agains one of the payees will be categorized to the account.
+
+The following example configuration makes use of the `PayeeCategorizer`:
+
+```python
+categorizer = PayeeCategorizer(
+    [{"account": "Expenses:Food:Groceries", "payees": ["^SUPERMARKET XY", "^MY DELI"]}]
+)
+...
+CONFIG = [
+    ECImporter(
+        IBAN_NUMBER,
+        'Assets:DKB:EC',
+        currency='EUR',
+        categorizer=categorizer,
+    ),
+...
+
+```
+
+CSV entries matching the payee regex will produce transactions such as the following:
+
+```beancount
+2021-03-01 * "SUPERMARKET XY SAGT DANKE"
+    Assets:DKB:EC                  -84.72 EUR
+    Expenses:Food:Groceries
+
+2021-03-01 * "MY DELI //LEIPZIG"
+    Assets:DKB:EC                  -15.72 EUR
+    Expenses:Food:Groceries
+```
+
+*Note*: When the `CreditImporter` is used, the payee field is not populated. Thus, the `PayeeCategorizer` will check against the narration field if no payee is present for a transaction.
+
 
 ## FAQ
 

--- a/beancount_dkb/__init__.py
+++ b/beancount_dkb/__init__.py
@@ -1,3 +1,4 @@
 from .credit import CreditImporter  # NOQA
 from .ec import ECImporter  # NOQA
+from .categorizer import PayeeCategorizer  # NOQA
 from .helpers import InvalidFormatError  # NOQA

--- a/beancount_dkb/categorizer.py
+++ b/beancount_dkb/categorizer.py
@@ -1,0 +1,29 @@
+import re
+from beancount.core import data
+
+
+class CategorizerProtocol:
+    def categorize(self, entry):
+        """"""
+
+
+class PayeeCategorizer(CategorizerProtocol):
+    def __init__(self, categories):
+        self.categories = categories
+
+    def categorize(self, entry):
+        for category in self.categories:
+            for payee in category['payees']:
+                if re.match(payee, (entry.payee or entry.narration)):
+                    entry.postings.append(
+                        data.Posting(
+                            category['account'], None, None, None, None, None,
+                        )
+                    )
+                    return entry
+        return entry
+
+
+class DefaultCategorizer(CategorizerProtocol):
+    def categorize(self, entry):
+        return entry

--- a/beancount_dkb/categorizer.py
+++ b/beancount_dkb/categorizer.py
@@ -13,12 +13,10 @@ class PayeeCategorizer(CategorizerProtocol):
 
     def categorize(self, entry):
         for category in self.categories:
-            for payee in category['payees']:
+            for payee in self.categories[category]:
                 if re.match(payee, (entry.payee or entry.narration)):
                     entry.postings.append(
-                        data.Posting(
-                            category['account'], None, None, None, None, None,
-                        )
+                        data.Posting(category, None, None, None, None, None,)
                     )
                     return entry
         return entry

--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -7,6 +7,7 @@ from beancount.core.amount import Amount
 from beancount.ingest import importer
 
 from .helpers import fmt_number_de, InvalidFormatError
+from .categorizer import DefaultCategorizer
 
 FIELDS = (
     'Buchungstag',
@@ -31,11 +32,13 @@ class ECImporter(importer.ImporterProtocol):
         currency='EUR',
         file_encoding='utf-8',
         meta_code=None,
+        categorizer=DefaultCategorizer(),
     ):
         self.account = account
         self.currency = currency
         self.file_encoding = file_encoding
         self.meta_code = meta_code
+        self.categorizer = categorizer
 
         self._expected_header_regex = re.compile(
             r'^"Kontonummer:";"'
@@ -175,15 +178,17 @@ class ECImporter(importer.ImporterProtocol):
                     ]
 
                     entries.append(
-                        data.Transaction(
-                            meta,
-                            date,
-                            self.FLAG,
-                            line['Auftraggeber / Begünstigter'],
-                            description,
-                            data.EMPTY_SET,
-                            data.EMPTY_SET,
-                            postings,
+                        self.categorizer.categorize(
+                            data.Transaction(
+                                meta,
+                                date,
+                                self.FLAG,
+                                line['Auftraggeber / Begünstigter'],
+                                description,
+                                data.EMPTY_SET,
+                                data.EMPTY_SET,
+                                postings,
+                            )
                         )
                     )
 


### PR DESCRIPTION
Allows for automatic transaction categorization based upon user defined rules.

See README.md for more details.

## TODO:
- [ ] Add tests

## Update
I'm actually reconsidering if this is a good idea. Other importers could also use this feature, and it is kind of pointless to implement on a per-implementer basis. It may be a better idea to make this a standalone importer decorator project that works with an `apply_hook` similar to https://github.com/beancount/smart_importer. This could be used to decorate any importer. Feedback and ideas welcome.