### PR TITLE
Use 'Wertstellung' instead of 'Belegdatum' to transaction dates

### DIFF
--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -149,7 +149,7 @@ class CreditImporter(importer.ImporterProtocol):
                     fmt_number_de(line['Betrag (EUR)']), self.currency
                 )
 
-                date = datetime.strptime(line['Belegdatum'], '%d.%m.%Y').date()
+                date = datetime.strptime(line['Wertstellung'], '%d.%m.%Y').date()
 
                 description = line['Beschreibung']
 

--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -149,7 +149,9 @@ class CreditImporter(importer.ImporterProtocol):
                     fmt_number_de(line['Betrag (EUR)']), self.currency
                 )
 
-                date = datetime.strptime(line['Wertstellung'], '%d.%m.%Y').date()
+                date = datetime.strptime(
+                    line['Wertstellung'], '%d.%m.%Y'
+                ).date()
 
                 description = line['Beschreibung']
 


### PR DESCRIPTION
Wertstellung is the date at which the amount is actually deducted from the account, so it is the right one to use here.

Closes #93 