### PR TITLE
Add compatibility for updated online banking interface

### DIFF
--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -1,29 +1,20 @@
-from collections import namedtuple
-import csv
-from datetime import datetime, timedelta
-from typing import Optional, Sequence, Dict
-from functools import partial
 import warnings
+from collections import namedtuple
+from datetime import datetime, timedelta
+from functools import partial
+from typing import Dict, Optional, Sequence
 
 from beancount.core import data
 from beancount.core.amount import Amount
 from beancount.ingest import importer
 
 from .exceptions import InvalidFormatError
-from .helpers import AccountMatcher, fmt_number_de
 from .extractors.ec import V1Extractor, V2Extractor
+from .helpers import AccountMatcher, csv_dict_reader, csv_reader, fmt_number_de
 
 Meta = namedtuple("Meta", ["value", "line_index"])
 
 new_posting = partial(data.Posting, cost=None, price=None, flag=None, meta=None)
-
-csv_reader = partial(
-    csv.reader, delimiter=";", quoting=csv.QUOTE_MINIMAL, quotechar='"'
-)
-
-csv_dict_reader = partial(
-    csv.DictReader, delimiter=";", quoting=csv.QUOTE_MINIMAL, quotechar='"'
-)
 
 
 class ECImporter(importer.ImporterProtocol):

--- a/beancount_dkb/extractors/ec.py
+++ b/beancount_dkb/extractors/ec.py
@@ -1,10 +1,9 @@
-from datetime import date, datetime
-from collections import namedtuple
 import re
-from typing import Optional, Dict
+from collections import namedtuple
+from datetime import date, datetime
+from typing import Dict, Optional
 
 from ..exceptions import InvalidFormatError
-
 
 Meta = namedtuple("Meta", ["value", "line_index"])
 
@@ -121,10 +120,13 @@ class V2Extractor(BaseExtractor):
     file_encoding = "utf-8-sig"
 
     def identify(self, file) -> bool:
-        with open(file.name, encoding=self.file_encoding) as fd:
-            lines = [line.strip() for line in fd.readlines()]
+        try:
+            with open(file.name, encoding=self.file_encoding) as fd:
+                lines = [line.strip() for line in fd.readlines()]
 
-        return self.HEADER in lines
+            return self.HEADER in lines
+        except UnicodeDecodeError:
+            return False
 
     def get_account_number(self, line: Dict[str, str]) -> str:
         return line["Gläubiger-ID"]

--- a/beancount_dkb/helpers.py
+++ b/beancount_dkb/helpers.py
@@ -1,8 +1,20 @@
+import csv
 import re
 from collections import namedtuple
+from functools import partial
 from typing import Optional, Sequence
 
 from beancount.core.number import Decimal
+
+csv_reader = partial(
+    csv.reader, delimiter=";", quoting=csv.QUOTE_MINIMAL, quotechar='"'
+)
+
+csv_dict_reader = partial(
+    csv.DictReader, delimiter=";", quoting=csv.QUOTE_MINIMAL, quotechar='"'
+)
+
+_MatcherEntry = namedtuple("_MatcherEntry", ["pattern", "account"])
 
 
 def fmt_number_de(value: str) -> Decimal:
@@ -10,9 +22,6 @@ def fmt_number_de(value: str) -> Decimal:
     decimal_sep = ","
 
     return Decimal(value.replace(thousands_sep, "").replace(decimal_sep, "."))
-
-
-_MatcherEntry = namedtuple("_MatcherEntry", ["pattern", "account"])
 
 
 class AccountMatcher:

--- a/poetry.lock
+++ b/poetry.lock
@@ -157,13 +157,13 @@ files = [
 
 [[package]]
 name = "chardet"
-version = "5.1.0"
+version = "5.2.0"
 description = "Universal encoding detector for Python 3"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "chardet-5.1.0-py3-none-any.whl", hash = "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"},
-    {file = "chardet-5.1.0.tar.gz", hash = "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5"},
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ fmt = "black beancount_dkb/ tests/"
 
 lint-black  = "black --check beancount_dkb/ tests/"
 lint-flake8 = "flake8 beancount_dkb/ tests/"
-lint = "task lint-black && task lint-flake8"
+lint-isort = "isort --check beancount_dkb/ tests/"
+lint = "task lint-black && task lint-flake8 && task lint-isort"
 
 test-pytest = "pytest tests/"
 test = "task test-pytest"

--- a/tests/test_credit_v1.py
+++ b/tests/test_credit_v1.py
@@ -2,15 +2,17 @@ import datetime
 from decimal import Decimal
 from textwrap import dedent
 
-from beancount.core.data import Amount, Balance
 import pytest
+from beancount.core.data import Amount, Balance
 
 from beancount_dkb import CreditImporter
 from beancount_dkb.extractors.credit import V1Extractor
 
 CARD_NUMBER = "1234********5678"
 
-HEADER = ";".join('"{}"'.format(field) for field in V1Extractor.FIELDS)
+HEADER = V1Extractor.HEADER
+
+ENCODING = V1Extractor.file_encoding
 
 
 def _format(string, kwargs):
@@ -42,7 +44,8 @@ def test_multiple_headers(tmp_file):
 
             """,
             dict(card_number=CARD_NUMBER, common=common),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -58,7 +61,8 @@ def test_multiple_headers(tmp_file):
 
             """,
             dict(card_number=CARD_NUMBER, common=common),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -78,10 +82,11 @@ def test_identify_correct(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             """,
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -104,10 +109,11 @@ def test_identify_prefixes(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             """,
             dict(prefix=prefix, suffix=suffix, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -127,10 +133,11 @@ def test_identify_invalid_iban(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             """,
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(other_iban, "Assets:DKB:Credit")
@@ -152,10 +159,11 @@ def test_extract_no_transactions(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             """,
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -178,11 +186,12 @@ def test_extract_transactions(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             "Ja";"15.01.2018";"15.01.2018";"REWE Filiale Muenchen";"-10,80";"";
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit", file_encoding="utf-8")
@@ -210,11 +219,12 @@ def test_extract_sets_timestamps(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             "Ja";"15.01.2018";"15.01.2018";"REWE Filiale Muenchen";"-10,80";"";
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit", file_encoding="utf-8")
@@ -242,11 +252,12 @@ def test_extract_with_zeitraum(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             "Ja";"15.01.2018";"15.01.2018";"REWE Filiale Muenchen";"-10,80";"";
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit", file_encoding="utf-8")
@@ -274,11 +285,12 @@ def test_file_date_with_zeitraum(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             "Ja";"15.01.2018";"15.01.2018";"REWE Filiale Muenchen";"-10,80";"";
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit", file_encoding="utf-8")
@@ -302,11 +314,12 @@ def test_emits_closing_balance_directive(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             "Ja";"15.01.2018";"15.01.2018";"REWE Filiale Muenchen";"-10,80";"";
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit", file_encoding="utf-8")
@@ -331,11 +344,12 @@ def test_file_date_is_set_correctly(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             "Ja";"15.01.2018";"15.01.2018";"REWE Filiale Muenchen";"-10,80";"";
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit", file_encoding="utf-8")
@@ -355,11 +369,12 @@ def test_extract_with_description_patterns(tmp_file):
             "Saldo:";"5000.01 EUR";
             "Datum:";"30.01.2018";
 
-            {header};
+            {header}
             "Ja";"15.01.2018";"15.01.2018";"REWE Filiale Muenchen";"-10,80";"";
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(
@@ -400,7 +415,8 @@ def test_extract_multiple_transactions(tmp_file):
             "Ja";"23.08.2023";"22.08.2023";"HabenzinsenZ 000001111 T 031   0000";"1,11";"";
             """,  # NOQA
             dict(prefix=prefix, suffix=suffix, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit")

--- a/tests/test_credit_v2.py
+++ b/tests/test_credit_v2.py
@@ -2,15 +2,15 @@ import datetime
 from decimal import Decimal
 from textwrap import dedent
 
-from beancount.core.data import Amount, Balance
 import pytest
+from beancount.core.data import Amount, Balance
 
 from beancount_dkb import CreditImporter
 from beancount_dkb.extractors.credit import V2Extractor
 
 CARD_NUMBER = "1234 •••• •••• 5678"
 
-HEADER = ";".join('"{}"'.format(field) for field in V2Extractor.FIELDS)
+HEADER = V2Extractor.HEADER
 
 
 def _format(string, kwargs):
@@ -30,9 +30,9 @@ def test_identify_correct(tmp_file):
             """
             "Karte";"Visa-Kreditkarte {card_number}"
             ""
-            "Saldo vom:";"5000.01 EUR"
+            "Saldo vom 31.01.2023:";"5000.01 EUR"
             ""
-            {header};
+            {header}
             """,
             dict(card_number=CARD_NUMBER, header=HEADER),
         )
@@ -53,9 +53,9 @@ def test_identify_prefixes(tmp_file):
             """
             "Karte";"Visa-Kreditkarte {prefix} •••• •••• {suffix}"
             ""
-            "Saldo:";"5000.01 EUR"
+            "Saldo vom 31.01.2023:";"5000.01 EUR"
             ""
-            {header};
+            {header}
             """,
             dict(prefix=prefix, suffix=suffix, header=HEADER),
         )
@@ -73,9 +73,9 @@ def test_identify_invalid_iban(tmp_file):
             """
             "Karte";"Visa-Kreditkarte {card_number}"
             ""
-            "Saldo:";"5000.01 EUR"
+            "Saldo vom 31.01.2023:";"5000.01 EUR"
             ""
-            {header};
+            {header}
             """,
             dict(card_number=CARD_NUMBER, header=HEADER),
         )
@@ -97,7 +97,7 @@ def test_extract_no_transactions(tmp_file):
             ""
             "Saldo vom 31.01.2023:";"5000.01 EUR"
             ""
-            {header};
+            {header}
             """,
             dict(card_number=CARD_NUMBER, header=HEADER),
         )
@@ -118,9 +118,9 @@ def test_extract_transactions(tmp_file):
             """
             "Karte";"Visa-Kreditkarte {card_number}"
             ""
-            "Saldo:";"5000.01 EUR"
+            "Saldo vom 31.01.2023:";"5000.01 EUR"
             ""
-            {header};
+            {header}
             "15.01.23";"15.01.23";"Gebucht";"REWE Filiale Muenchen";"Im Geschäft";"-10,80 €";""
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
@@ -149,7 +149,7 @@ def test_emits_closing_balance_directive(tmp_file):
             ""
             "Saldo vom 31.01.2023:";"5000.01 EUR"
             ""
-            {header};
+            {header}
             "15.01.23";"15.01.23";"Gebucht";"REWE Filiale Muenchen";"Im Geschäft";"-10,80 €";""
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),
@@ -173,9 +173,9 @@ def test_extract_with_description_patterns(tmp_file):
             """
             "Karte";"Visa-Kreditkarte {card_number}";
             ""
-            "Saldo:";"5000.01 EUR";
+            "Saldo vom 31.01.2023:";"5000.01 EUR";
             ""
-            {header};
+            {header}
             "15.01.23";"15.01.23";"Gebucht";"REWE Filiale Muenchen";"Im Geschäft";"-10,80 €";""
             """,  # NOQA
             dict(card_number=CARD_NUMBER, header=HEADER),

--- a/tests/test_ec_v1.py
+++ b/tests/test_ec_v1.py
@@ -2,12 +2,11 @@ import datetime
 from decimal import Decimal
 from textwrap import dedent
 
-from beancount.core.data import Amount, Balance
 import pytest
+from beancount.core.data import Amount, Balance
 
 from beancount_dkb import ECImporter
 from beancount_dkb.extractors.ec import V1Extractor
-
 
 FORMATTED_IBAN = "DE99 9999 9999 9999 9999 99"
 

--- a/tests/test_ec_v1.py
+++ b/tests/test_ec_v1.py
@@ -13,7 +13,9 @@ FORMATTED_IBAN = "DE99 9999 9999 9999 9999 99"
 
 IBAN = FORMATTED_IBAN.replace(" ", "")
 
-HEADER = ";".join('"{}"'.format(field) for field in V1Extractor.FIELDS)
+HEADER = V1Extractor.HEADER
+
+ENCODING = V1Extractor.file_encoding
 
 
 def _format(string, kwargs):
@@ -37,10 +39,11 @@ def test_identify_correct(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -59,10 +62,11 @@ def test_identify_tagesgeld(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -81,10 +85,11 @@ def test_identify_with_nonstandard_account_name(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -97,16 +102,17 @@ def test_identify_with_exotic_account_name(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Kontonummer:";"{iban} / Girökóntô, Γιροκοντώ, 預金, حساب البنك";
+            "Kontonummer:";"{iban} / Girökóntô";
 
             "Von:";"01.01.2018";
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -125,10 +131,11 @@ def test_identify_with_formatted_iban(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -147,7 +154,7 @@ def test_identify_invalid_iban(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             """,
             dict(iban=IBAN, header=HEADER),
         )
@@ -171,10 +178,11 @@ def test_extract_no_transactions(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -196,15 +204,16 @@ def test_extract_transactions(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             "06.05.2020";"06.05.2020";"Gutschrift";"From Someone";"";"DE88700222000012345678";"FDDODEMMXXX";"1,00";"";"";"NOTPROVIDED";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
@@ -239,15 +248,16 @@ def test_extract_tagesgeld(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             "06.05.2020";"06.05.2020";"Gutschrift";"From Someone";"";"DE88700222000012345678";"FDDODEMMXXX";"1,00";"";"";"NOTPROVIDED";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
@@ -282,14 +292,15 @@ def test_extract_sets_timestamps(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     assert not importer._date_from
     assert not importer._date_to
@@ -316,14 +327,15 @@ def test_tagessaldo_emits_balance_directive(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "20.01.2018";"";"";"";"Tagessaldo";"";"";"2.500,01";
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
@@ -344,14 +356,15 @@ def test_tagessaldo_with_empty_balance_does_not_crash(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "20.01.2018";"";"";"";"Tagessaldo";"";"";"";
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
@@ -372,14 +385,15 @@ def test_file_date_is_set_correctly(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "20.01.2018";"";"";"";"Tagessaldo";"";"";"2.500,01";
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         assert importer.file_date(fd) == datetime.date(2018, 1, 31)
@@ -395,14 +409,15 @@ def test_emits_closing_balance_directive(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
@@ -411,7 +426,7 @@ def test_emits_closing_balance_directive(tmp_file):
     assert isinstance(directives[1], Balance)
     assert directives[1].date == datetime.date(2018, 2, 1)
     assert directives[1].amount == Amount(Decimal("5000.01"), currency="EUR")
-    assert directives[1].meta["lineno"] == 4
+    assert directives[1].meta["lineno"] == 5
 
 
 def test_mismatching_dates_in_meta(tmp_file):
@@ -424,14 +439,15 @@ def test_mismatching_dates_in_meta(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2019:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
@@ -452,16 +468,15 @@ def test_meta_code_is_added(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(
-        IBAN, "Assets:DKB:EC", file_encoding="utf-8", meta_code="code"
-    )
+    importer = ECImporter(IBAN, "Assets:DKB:EC", meta_code="code")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
@@ -483,17 +498,17 @@ def test_extract_with_payee_patterns(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = ECImporter(
         IBAN,
         "Assets:DKB:EC",
-        file_encoding="utf-8",
         payee_patterns=[("REWE Filialen", "Expenses:Supermarket:REWE")],
     )
 
@@ -520,17 +535,17 @@ def test_extract_with_description_patterns(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = ECImporter(
         IBAN,
         "Assets:DKB:EC",
-        file_encoding="utf-8",
         description_patterns=[("SAGT DANKE", "Expenses:Supermarket:REWE")],
     )
 
@@ -557,17 +572,17 @@ def test_extract_with_payee_and_description_patterns(tmp_file):
             "Bis:";"31.01.2018";
             "Kontostand vom 31.01.2018:";"5.000,01 EUR";
 
-            {header};
+            {header}
             "16.01.2018";"16.01.2018";"Lastschrift";"REWE Filialen Voll";"REWE SAGT DANKE.";"DE00000000000000000000";"AAAAAAAA";"-15,37";"000000000000000000    ";"0000000000000000000000";"";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = ECImporter(
         IBAN,
         "Assets:DKB:EC",
-        file_encoding="utf-8",
         payee_patterns=[("REWE Filialen", "Expenses:Supermarket:REWE")],
         description_patterns=[("SAGT DANKE", "Expenses:Supermarket:REWE")],
     )
@@ -607,10 +622,11 @@ def test_extract_multiple_transactions(tmp_file):
             "02.10.2023";"02.10.2023";"Kartenzahlung";"ALDI SUED";"2023-09-30      Debitk.11 VISA Debit";"11111111111111111111";"BYLADEM1001";"-16,45";"";"";"111111111111111";
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)

--- a/tests/test_ec_v2.py
+++ b/tests/test_ec_v2.py
@@ -2,12 +2,11 @@ import datetime
 from decimal import Decimal
 from textwrap import dedent
 
-from beancount.core.data import Amount, Balance
 import pytest
+from beancount.core.data import Amount, Balance
 
 from beancount_dkb import ECImporter
 from beancount_dkb.ec import V2Extractor
-
 
 FORMATTED_IBAN = "DE99 9999 9999 9999 9999 99"
 

--- a/tests/test_ec_v2.py
+++ b/tests/test_ec_v2.py
@@ -13,7 +13,9 @@ FORMATTED_IBAN = "DE99 9999 9999 9999 9999 99"
 
 IBAN = FORMATTED_IBAN.replace(" ", "")
 
-HEADER = ";".join('"{}"'.format(field) for field in V2Extractor.FIELDS)
+HEADER = V2Extractor.HEADER
+
+ENCODING = V2Extractor.file_encoding
 
 
 def _format(string, kwargs):
@@ -31,112 +33,19 @@ def test_identify_correct(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}";
             ""
-            "Von:";"01.01.2023";
-            "Bis:";"31.01.2023";
-            "Kontostand vom 31.01.2023:";"5.000,01 EUR";
+            "Kontostand vom 30.06.2023:";"5.000,01 EUR";
             ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"2023-01-15T10:10";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
+            {header}
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
         assert importer.identify(fd)
-
-
-def test_identify_tagesgeld(tmp_file):
-    importer = ECImporter(IBAN, "Assets:DKB:EC")
-
-    tmp_file.write_text(
-        _format(
-            """
-            "Konto";"Tagesgeld {iban}";
-            ""
-            "Von:";"01.01.2023";
-            "Bis:";"31.01.2023";
-            "Kontostand vom 31.01.2023:";"5.000,01 EUR";
-            ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"2023-01-15T10:10";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
-            """,  # NOQA
-            dict(iban=IBAN, header=HEADER),
-        )
-    )
-
-    with tmp_file.open() as fd:
-        assert importer.identify(fd)
-
-
-def test_identify_with_nonstandard_account_name(tmp_file):
-    importer = ECImporter(IBAN, "Assets:DKB:EC")
-
-    tmp_file.write_text(
-        _format(
-            """
-            "Konto";"Girokonto {iban}";
-            ""
-            "Von:";"01.01.2023";
-            "Bis:";"31.01.2023";
-            "Kontostand vom 31.01.2023:";"5.000,01 EUR";
-            ""
-            {header};
-            """,
-            dict(iban=IBAN, header=HEADER),
-        )
-    )
-
-    with tmp_file.open() as fd:
-        assert importer.identify(fd)
-
-
-def test_identify_with_formatted_iban(tmp_file):
-    importer = ECImporter(FORMATTED_IBAN, "Assets:DKB:EC")
-
-    tmp_file.write_text(
-        _format(
-            """
-            "Konto";"Girokonto {iban}";
-            ""
-            "Von:";"01.01.2023";
-            "Bis:";"31.01.2023";
-            "Kontostand vom 31.01.2023:";"5.000,01 EUR";
-            ""
-            {header};
-            """,
-            dict(iban=IBAN, header=HEADER),
-        )
-    )
-
-    with tmp_file.open() as fd:
-        assert importer.identify(fd)
-
-
-def test_identify_invalid_iban(tmp_file):
-    other_iban = "DE00000000000000000000"
-
-    tmp_file.write_text(
-        _format(
-            """
-            "Konto";"Girokonto {iban}";
-            ""
-            "Von:";"01.01.2023";
-            "Bis:";"31.01.2023";
-            "Kontostand vom 31.01.2023:";"5.000,01 EUR";
-            ""
-            {header};
-            """,
-            dict(iban=IBAN, header=HEADER),
-        )
-    )
-
-    importer = ECImporter(other_iban, "Assets:DKB:EC")
-
-    with tmp_file.open() as fd:
-        assert not importer.identify(fd)
 
 
 def test_extract_no_transactions(tmp_file):
@@ -145,16 +54,14 @@ def test_extract_no_transactions(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}";
             ""
-            "Von:";"01.01.2023";
-            "Bis:";"31.01.2023";
-            "Kontostand vom 31.01.2023:";"5.000,01 EUR";
+            "Kontostand vom 30.06.2023:";"5.000,01 EUR";
             ""
-            {header};
+            {header}
             """,
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     with tmp_file.open() as fd:
@@ -162,7 +69,7 @@ def test_extract_no_transactions(tmp_file):
 
     assert len(directives) == 1
     assert isinstance(directives[0], Balance)
-    assert directives[0].date == datetime.date(2023, 2, 1)
+    assert directives[0].date == datetime.date(2023, 7, 1)
     assert directives[0].amount == Amount(Decimal("5000.01"), currency="EUR")
 
 
@@ -170,110 +77,60 @@ def test_extract_transactions(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}"
             ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
+            "Kontostand vom 30.06.2023:";"5001,01 EUR"
             ""
             {header}
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
-            "20.01.23";"20.01.23";"Gebucht";"COMPANY INC";"MAX MUSTERMANN";"Money";"Eingang";"100,00 €";"";"";""
+            "01.06.23";"01.06.23";"Gebucht";"COMPANY INC";"MAX MUSTERMANN";"Lohn und Gehalt";"Eingang";"DE00000000000000000000";"1.000,0";"";"";""
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
 
     assert len(directives) == 3
 
-    # first directive
-
-    assert directives[0].date == datetime.date(2023, 1, 15)
-    assert directives[0].payee == "EDEKA//MUENCHEN/DE"
-    assert directives[0].narration == "EDEKA SAGT DANKE"
-
-    assert len(directives[0].postings) == 1
-    assert directives[0].postings[0].account == "Assets:DKB:EC"
-    assert directives[0].postings[0].units.currency == "EUR"
-    assert directives[0].postings[0].units.number == Decimal("-9.56")
-
-    # second directive
-
-    assert directives[1].date == datetime.date(2023, 1, 20)
-    assert directives[1].payee == "COMPANY INC"
-    assert directives[1].narration == "Money"
+    assert directives[0].date == datetime.date(2023, 6, 1)
+    assert directives[0].payee == "COMPANY INC"
+    assert directives[0].narration == "Lohn und Gehalt"
 
     assert len(directives[1].postings) == 1
+    assert directives[0].postings[0].account == "Assets:DKB:EC"
+    assert directives[0].postings[0].units.currency == "EUR"
+    assert directives[0].postings[0].units.number == Decimal("1000.00")
+
+    assert directives[1].date == datetime.date(2023, 6, 15)
+    assert directives[1].payee == "EDEKA//MUENCHEN/DE"
+    assert directives[1].narration == "EDEKA SAGT DANKE"
+
+    assert len(directives[0].postings) == 1
     assert directives[1].postings[0].account == "Assets:DKB:EC"
     assert directives[1].postings[0].units.currency == "EUR"
-    assert directives[1].postings[0].units.number == Decimal("100.00")
+    assert directives[1].postings[0].units.number == Decimal("-8.67")
 
 
-def test_extract_tagesgeld(tmp_file):
+def test_extract_sets_internal_values(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Tagesgeld {iban}"
             ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
+            "Kontostand vom 30.06.2023:";"5001,01 EUR"
             ""
             {header}
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
-            "20.01.23";"20.01.23";"Gebucht";"COMPANY INC";"MAX MUSTERMANN";"Money";"Eingang";"100,00 €";"";"";""
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
-
-    with tmp_file.open() as fd:
-        directives = importer.extract(fd)
-
-    assert len(directives) == 3
-
-    # first directive
-
-    assert directives[0].date == datetime.date(2023, 1, 15)
-    assert directives[0].payee == "EDEKA//MUENCHEN/DE"
-    assert directives[0].narration == "EDEKA SAGT DANKE"
-
-    assert len(directives[0].postings) == 1
-    assert directives[0].postings[0].account == "Assets:DKB:EC"
-    assert directives[0].postings[0].units.currency == "EUR"
-    assert directives[0].postings[0].units.number == Decimal("-9.56")
-
-    # second directive
-
-    assert directives[1].date == datetime.date(2023, 1, 20)
-    assert directives[1].payee == "COMPANY INC"
-    assert directives[1].narration == "Money"
-
-    assert len(directives[1].postings) == 1
-    assert directives[1].postings[0].account == "Assets:DKB:EC"
-    assert directives[1].postings[0].units.currency == "EUR"
-    assert directives[1].postings[0].units.number == Decimal("100.00")
-
-
-def test_extract_sets_timestamps(tmp_file):
-    tmp_file.write_text(
-        _format(
-            """
-            "Konto";"Girokonto {iban}"
-            ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
-            ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
-            """,  # NOQA
-            dict(iban=IBAN, header=HEADER),
-        )
-    )
-
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     assert not importer._date_from
     assert not importer._date_to
@@ -285,32 +142,32 @@ def test_extract_sets_timestamps(tmp_file):
 
     assert directives
     assert importer._balance_amount == Amount(Decimal("5001.01"), currency="EUR")
-    assert importer._balance_date == datetime.date(2023, 2, 1)
+    assert importer._balance_date == datetime.date(2023, 7, 1)
 
 
 def test_emits_closing_balance_directive(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}"
             ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
+            "Kontostand vom 30.06.2023:";"5001,01 EUR"
             ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
+            {header}
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC", file_encoding="utf-8")
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
 
     assert len(directives) == 2
     assert isinstance(directives[1], Balance)
-    assert directives[1].date == datetime.date(2023, 2, 1)
+    assert directives[1].date == datetime.date(2023, 7, 1)
     assert directives[1].amount == Amount(Decimal("5001.01"), currency="EUR")
     assert directives[1].meta["lineno"] == 2
 
@@ -319,26 +176,24 @@ def test_meta_code_is_added(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}"
             ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
+            "Kontostand vom 30.06.2023:";"5001,01 EUR"
             ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
+            {header}
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
-    importer = ECImporter(
-        IBAN, "Assets:DKB:EC", file_encoding="utf-8", meta_code="code"
-    )
+    importer = ECImporter(IBAN, "Assets:DKB:EC", meta_code="code")
 
     with tmp_file.open() as fd:
         directives = importer.extract(fd)
 
     assert len(directives) == 2
-    assert directives[0].date == datetime.date(2023, 1, 15)
+    assert directives[0].date == datetime.date(2023, 6, 15)
     assert directives[0].payee == "EDEKA//MUENCHEN/DE"
     assert directives[0].narration == "EDEKA SAGT DANKE"
     assert directives[0].meta["code"] == "Ausgang"
@@ -348,21 +203,20 @@ def test_extract_with_payee_patterns(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}"
             ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
+            "Kontostand vom 30.06.2023:";"5001,01 EUR"
             ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
+            {header}
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = ECImporter(
         IBAN,
         "Assets:DKB:EC",
-        file_encoding="utf-8",
         payee_patterns=[("EDEKA", "Expenses:Supermarket:EDEKA")],
     )
 
@@ -373,7 +227,7 @@ def test_extract_with_payee_patterns(tmp_file):
     assert len(directives[0].postings) == 2
     assert directives[0].postings[0].account == "Assets:DKB:EC"
     assert directives[0].postings[0].units.currency == "EUR"
-    assert directives[0].postings[0].units.number == Decimal("-9.56")
+    assert directives[0].postings[0].units.number == Decimal("-8.67")
 
     assert directives[0].postings[1].account == "Expenses:Supermarket:EDEKA"
     assert directives[0].postings[1].units is None
@@ -383,21 +237,20 @@ def test_extract_with_description_patterns(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}"
             ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
+            "Kontostand vom 30.06.2023:";"5001,01 EUR"
             ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
+            {header}
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = ECImporter(
         IBAN,
         "Assets:DKB:EC",
-        file_encoding="utf-8",
         description_patterns=[("SAGT DANKE", "Expenses:Supermarket:EDEKA")],
     )
 
@@ -408,7 +261,7 @@ def test_extract_with_description_patterns(tmp_file):
     assert len(directives[0].postings) == 2
     assert directives[0].postings[0].account == "Assets:DKB:EC"
     assert directives[0].postings[0].units.currency == "EUR"
-    assert directives[0].postings[0].units.number == Decimal("-9.56")
+    assert directives[0].postings[0].units.number == Decimal("-8.67")
 
     assert directives[0].postings[1].account == "Expenses:Supermarket:EDEKA"
     assert directives[0].postings[1].units is None
@@ -418,21 +271,20 @@ def test_extract_with_payee_and_description_patterns(tmp_file):
     tmp_file.write_text(
         _format(
             """
-            "Konto";"Girokonto {iban}"
             ""
-            "Kontostand vom 31.01.2023:";"5001,01 EUR"
+            "Kontostand vom 30.06.2023:";"5001,01 EUR"
             ""
-            {header};
-            "15.01.23";"15.01.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"-9,56 €";"DE0000000000000000";"";"00000000000000000000000000"
+            {header}
+            "15.06.23";"15.06.23";"Gebucht";"ISSUER";"EDEKA//MUENCHEN/DE";"EDEKA SAGT DANKE";"Ausgang";"DE00000000000000000000";"-8,67";"DE9100112233445566";"";"00000000000000000000000000"
             """,  # NOQA
             dict(iban=IBAN, header=HEADER),
-        )
+        ),
+        encoding=ENCODING,
     )
 
     importer = ECImporter(
         IBAN,
         "Assets:DKB:EC",
-        file_encoding="utf-8",
         payee_patterns=[("EDEKA", "Expenses:Supermarket:EDEKA")],
         description_patterns=[("SAGT DANKE", "Expenses:Supermarket:EDEKA")],
     )
@@ -445,13 +297,13 @@ def test_extract_with_payee_and_description_patterns(tmp_file):
     assert len(directives[0].postings) == 2
     assert directives[0].postings[0].account == "Assets:DKB:EC"
     assert directives[0].postings[0].units.currency == "EUR"
-    assert directives[0].postings[0].units.number == Decimal("-9.56")
+    assert directives[0].postings[0].units.number == Decimal("-8.67")
 
     assert directives[0].postings[1].account == "Expenses:Supermarket:EDEKA"
     assert directives[0].postings[1].units is None
 
     assert len(user_warnings) == 1
     assert user_warnings[0].message.args[0] == (
-        "Line 6 matches both payee_patterns and description_patterns. "
+        "Line 5 matches both payee_patterns and description_patterns. "
         "Picking payee_pattern."
     )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 from beancount.core.number import Decimal
+
 from beancount_dkb.helpers import fmt_number_de
 
 


### PR DESCRIPTION
- Simplify `ECImporter` and `CreditImporter`
  - No more per-line assertions, we rather just load all the files and split the lines into before- and after-header lines.
  - The lines before header are considered metadata and the ones following the header are transactions.
- Remove `file_encoding` parameter
  - Older banking interface files are always ISO-8859-1 and the newer ones are UTF-8 encoded (with BOM in the very beginning).