### PR TITLE
Fixes missing setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,6 @@ test-pytest = "pytest tests/"
 test = "task test-pytest"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "setuptools"]
 build-backend = "poetry.masonry.api"
 


### PR DESCRIPTION
With this change it is possible to install the package locally like `pip install -e /some_local_path/beancount-dkb`