### PR TITLE
feature: select account if multiple patterns match

### DIFF
--- a/beancount_dkb/helpers.py
+++ b/beancount_dkb/helpers.py
@@ -2,7 +2,7 @@ import csv
 import re
 from collections import namedtuple
 from functools import partial
-from typing import Optional, Sequence
+from typing import Optional, Sequence, List
 
 from babel.numbers import parse_decimal
 from beancount.core.number import Decimal
@@ -48,10 +48,9 @@ class AccountMatcher:
     def add(self, regex: str, account: str) -> None:
         self.patterns.append(_MatcherEntry(re.compile(regex), account))
 
-    def account_for(self, string: str) -> Optional[str]:
+    def accounts_for(self, string: str) -> List[str]:
+        matches = []
         for pattern, account in self.patterns:
             if re.search(pattern, string):
-                return account
-
-    def account_matches(self, string: str) -> bool:
-        return bool(self.account_for(string))
+                matches.append(account)
+        return matches


### PR DESCRIPTION
This PR enhances the importer to let the user choose which account to use during import when multiple patterns match.

Let's assume (1) you have this EC csv

```csv
﻿"Girokonto";"DE00000000000000000000"
"Zeitraum:";"30.12.2024 - 31.12.2024"
"Kontostand vom 04.01.2025:";"00,00 €"
""
"Buchungsdatum";"Wertstellung";"Status";"Zahlungspflichtige*r";"Zahlungsempfänger*in";"Verwendungszweck";"Umsatztyp";"IBAN";"Betrag (€)";"Gläubiger-ID";"Mandatsreferenz";"Kundenreferenz"
"30.12.24";"30.12.24";"Gebucht";"PAYEE";"PAYEE";"MY DESCRIPTION";"Ausgang";"DE00000000000000000000";"-100";"";"";""
```

And (2) that you have this toml configuration

```toml
[tool.beancount-dkb.ec]
iban = "DE00000000000000000000"
account_name = "Assets:Cash:DKB"
description_patterns=[
	[
		"PAYEE",
		"Income:Account_1"
	],
	[
		"PAYEE",
		"Income:Account_2"
	],
]
description_patterns=[
	[
		"MY DESCRIPTION",
		"Expenses:Account_1"
	],
	[
		"MY DESCRIPTION",
		"Expenses:Account_2"
	],
]
```

If you run the importer you should get an output like this prompting you to choose the account to post against:

```
$ beancount-dkb-ec extract /tmp/test.csv
* /tmp/test.csv ...

Multiple patterns match for line 6.
Please choose the account to post against.

2024-12-30 * "PAYEE" "MY DESCRIPTION" 
        Assets:Cash:DKB -100 EUR 
[0]     Expenses:Account_1 (<-- Default)
[1]     Income:Account_1
[2]     Income:Account_2
[3]     Expenses:Account_2
Choose the correct account: 2

Posting against account Income:Account_2
 OK
# FILE OUTPUT BEGINS HERE
;; -*- mode: beancount -*-

**** /tmp/Umsatzliste_Girokonto_DE08120300001012453591.csv

2024-12-30 * "PAYEE" "MY DESCRIPTION"
  code: "Ausgang"
  Assets:Cash:DKB   -100 EUR
  Income:Account_2

2025-01-05 balance Assets:Cash:DKB                                 0.00 EUR
```

The same works for multiple matching CC description patterns