### PR TITLE
add trailing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ importers = (
         "9999 9999 9999 9999",
         'Assets:DKB:Credit',
         currency='EUR',
-    )
+    ),
 )
 
 if __name__ == "__main__":
@@ -77,7 +77,7 @@ CONFIG = [
         "9999 9999 9999 9999",
         "Assets:DKB:Credit",
         currency='EUR',
-    )
+    ),
 ]
 ```
 


### PR DESCRIPTION
... just to avoid users forgetting it (looking at myself 🙂) if they only have one importer.

Without trailing comma, obvs, you get:

```
TypeError: 'ECImporter' object is not iterable
```