### PR TITLE
Use 2 decimal places in the output

### DIFF
--- a/beancount_dkb/helpers.py
+++ b/beancount_dkb/helpers.py
@@ -33,17 +33,19 @@ class Meta(NamedTuple):
 def fmt_number_de(value: str) -> Decimal:
     """
     Format a de_DE locale formatted number
+    Use always 2 decimal digits
     """
 
-    return parse_decimal(value, locale="de_DE")
+    return parse_decimal(value, locale="de_DE").quantize(Decimal('.01'))
 
 
 def fmt_number_en(value: str) -> Decimal:
     """
     Format an en_US locale formatted number
+    Use always 2 decimal digits
     """
 
-    return parse_decimal(value, locale="en_US")
+    return parse_decimal(value, locale="en_US").quantize(Decimal('.01'))
 
 
 class AccountMatcher:

--- a/tests/test_ec_v2.py
+++ b/tests/test_ec_v2.py
@@ -183,6 +183,8 @@ def test_extract_transactions(tmp_file_multiple_transaction):
     assert directives[0].postings[0].account == "Assets:DKB:EC"
     assert directives[0].postings[0].units.currency == "EUR"
     assert directives[0].postings[0].units.number == Decimal("1000.00")
+    # test that number contains 2 decimal places even if source contained only one:
+    assert directives[0].postings[0].units.number.compare_total(Decimal("1000.00")) == Decimal('0')
 
     assert directives[1].date == datetime.date(2023, 6, 15)
     assert directives[1].payee == "EDEKA//MUENCHEN/DE"
@@ -201,6 +203,8 @@ def test_extract_transactions(tmp_file_multiple_transaction):
     assert directives[2].postings[0].account == "Assets:DKB:EC"
     assert directives[2].postings[0].units.currency == "EUR"
     assert directives[2].postings[0].units.number == Decimal("-1450")
+    # test that number contains 2 decimal places even if source contained no decimal places:
+    assert directives[2].postings[0].units.number.compare_total(Decimal("-1450.00")) == Decimal('0')
 
 
 def test_extract_sets_internal_values(tmp_file_single_transaction):


### PR DESCRIPTION
Hi,

CSV account exports contain numbers with 0, 1, or 2 decimal places. This change standardizes the output to 2 decimal places.