### PR TITLE
Add exact counterparty IBAN matching for EC imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,15 +150,21 @@ And this is the resulting transaction using `meta_code='code'`
 It's possible to give the importer classes hints if you'd like them to include a
 second posting based on specific characteristics of the original transaction.
 
-For instance, if the payee or the description in a transaction always matches a
-certain value, it's possible to tell the `ECImporter` or `CreditImporter` to
-automatically place a second posting in the returned lits of transactions.
+For instance, if the payee, description, or counterparty IBAN in a transaction
+always matches a certain value, it's possible to tell the `ECImporter` or
+`CreditImporter` to automatically place a second posting in the returned list of
+transactions.
 
 #### `ECImporter`
 
 `ECImporter` accepts `payee_patterns` and `description_patterns` arguments, which should
 be a list of `(pattern, account)` tuples. The `pattern` is compiled using `re.compile`,
 so feel free to use regular expressions there.
+
+`ECImporter` also accepts an `iban_matcher` argument, which should be a list of
+`(iban, account)` tuples. The IBAN is normalized by removing whitespace and
+uppercasing before being compared exactly against the counterparty IBAN field in
+current DKB EC exports. `iban_matcher` is not available for legacy exports (before 2023). So, it is ignored for those files.
 
 ##### Beancount 3.x
 
@@ -173,6 +179,9 @@ importers = (
         payee_patterns=[
             ("REWE", "Expenses:Supermarket:REWE"),
             (r"N*TFL*X", "Expenses:Online:Netflix"),
+        ],
+        iban_matcher=[
+            ("DE88 8888 8888 8888 8888 88", "Assets:Bank:HYSA"),
         ],
     ),
 )
@@ -193,6 +202,9 @@ CONFIG = [
         payee_patterns=[
             ("REWE", "Expenses:Supermarket:REWE"),
             ("NETFLIX", "Expenses:Online:Netflix"),
+        ],
+        iban_matcher=[
+            ("DE88 8888 8888 8888 8888 88", "Assets:Bank:HYSA"),
         ],
     ),
 ```

--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -10,7 +10,7 @@ from beangulp.importer import Importer
 
 from .exceptions import InvalidFormatError
 from .extractors.ec import V1Extractor, V2Extractor
-from .helpers import AccountMatcher, Meta, fmt_number_de
+from .helpers import AccountMatcher, IBANMatcher, Meta, fmt_number_de
 
 new_posting = partial(data.Posting, cost=None, price=None, flag=None, meta=None)
 
@@ -25,11 +25,13 @@ class ECImporter(Importer):
         meta_code: Optional[str] = None,
         payee_patterns: Optional[Sequence] = None,
         description_patterns: Optional[Sequence] = None,
+        iban_matcher: Optional[Sequence] = None,
     ):
         self.iban = iban
         self.account_name = account_name
         self.currency = currency
         self.meta_code = meta_code
+        self.iban_matcher = IBANMatcher(iban_matcher)
         self.payee_matcher = AccountMatcher(payee_patterns)
         self.description_matcher = AccountMatcher(description_patterns)
 
@@ -146,38 +148,60 @@ class ECImporter(Importer):
 
                 description = extractor.get_description(line)
                 payee = extractor.get_payee(line)
+                counterparty_iban = extractor.get_counterparty_iban(line)
 
                 postings = [
                     new_posting(account=self.account(filepath), units=amount),
                 ]
 
-                payee_match = self.payee_matcher.account_matches(payee)
-                description_match = self.description_matcher.account_matches(
-                    description
-                )
+                matcher_accounts = [
+                    (
+                        "iban_matcher",
+                        "iban_matcher",
+                        self.iban_matcher.account_for(counterparty_iban),
+                    ),
+                    (
+                        "payee_patterns",
+                        "payee_pattern",
+                        self.payee_matcher.account_for(payee),
+                    ),
+                    (
+                        "description_patterns",
+                        "description_pattern",
+                        self.description_matcher.account_for(description),
+                    ),
+                ]
+                matcher_accounts = [
+                    matcher_account
+                    for matcher_account in matcher_accounts
+                    if matcher_account[2] is not None
+                ]
 
-                if payee_match and description_match:
+                if len(matcher_accounts) > 1:
+                    matcher_names = [
+                        matcher_account[0] for matcher_account in matcher_accounts
+                    ]
+                    selected_matcher = matcher_accounts[0][1]
+
+                    if len(matcher_names) == 2:
+                        matcher_names_text = (
+                            f"both {matcher_names[0]} and {matcher_names[1]}"
+                        )
+                    else:
+                        matcher_names_text = (
+                            f"{', '.join(matcher_names[:-1])} "
+                            f"and {matcher_names[-1]}"
+                        )
+
                     warnings.warn(
-                        f"Line {line_index + 1} matches both payee_patterns and "
-                        "description_patterns. Picking payee_pattern.",
+                        f"Line {line_index + 1} matches {matcher_names_text}. "
+                        f"Picking {selected_matcher}.",
                     )
+
+                if matcher_accounts:
                     postings.append(
                         new_posting(
-                            account=self.payee_matcher.account_for(payee),
-                            units=None,
-                        )
-                    )
-                elif payee_match:
-                    postings.append(
-                        new_posting(
-                            account=self.payee_matcher.account_for(payee),
-                            units=None,
-                        )
-                    )
-                elif description_match:
-                    postings.append(
-                        new_posting(
-                            account=self.description_matcher.account_for(description),
+                            account=matcher_accounts[0][2],
                             units=None,
                         )
                     )

--- a/beancount_dkb/extractors/ec.py
+++ b/beancount_dkb/extractors/ec.py
@@ -77,6 +77,9 @@ class BaseExtractor:
     def get_booking_text(self, line: Dict[str, str]) -> str:
         raise NotImplementedError()
 
+    def get_counterparty_iban(self, line: Dict[str, str]) -> Optional[str]:
+        raise NotImplementedError()
+
     def get_description(self, line: Dict[str, str]) -> str:
         raise NotImplementedError()
 
@@ -147,6 +150,9 @@ class V1Extractor(BaseExtractor):
 
     def get_booking_text(self, line: Dict[str, str]) -> str:
         return line["Buchungstext"]
+
+    def get_counterparty_iban(self, line: Dict[str, str]) -> Optional[str]:
+        return None
 
     def get_description(self, line: Dict[str, str]) -> str:
         purpose = self.get_purpose(line) or self.get_account_number(line)
@@ -267,6 +273,9 @@ class V2Extractor(BaseExtractor):
 
     def get_booking_text(self, line: Dict[str, str]) -> str:
         return line["Umsatztyp"]
+
+    def get_counterparty_iban(self, line: Dict[str, str]) -> Optional[str]:
+        return line["IBAN"]
 
     def get_description(self, line: Dict[str, str]) -> str:
         return self.get_purpose(line)

--- a/beancount_dkb/helpers.py
+++ b/beancount_dkb/helpers.py
@@ -1,5 +1,6 @@
 import csv
 import re
+import warnings
 from functools import partial
 from typing import NamedTuple, Optional, Sequence
 
@@ -17,6 +18,11 @@ csv_dict_reader = partial(
 
 class _MatcherEntry(NamedTuple):
     pattern: re.Pattern
+    account: str
+
+
+class _IBANMatcherEntry(NamedTuple):
+    iban: str
     account: str
 
 
@@ -74,3 +80,43 @@ class AccountMatcher:
 
     def account_matches(self, string: str) -> bool:
         return bool(self.account_for(string))
+
+
+def _normalize_iban(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+
+    return re.sub(r"\s+", "", value, flags=re.UNICODE).upper()
+
+
+class IBANMatcher:
+    def __init__(self, entries: Optional[Sequence] = None):
+        self.entries = []
+
+        if entries is not None:
+            for iban, account in entries:
+                self.add(iban, account)
+
+    def add(self, iban: Optional[str], account: str) -> None:
+        normalized_iban = _normalize_iban(iban)
+
+        if not normalized_iban:
+            warnings.warn(
+                f"Ignoring empty iban_matcher entry for account {account}.",
+            )
+            return
+
+        self.entries.append(_IBANMatcherEntry(normalized_iban, account))
+
+    def account_for(self, value: Optional[str]) -> Optional[str]:
+        normalized_iban = _normalize_iban(value)
+
+        if not normalized_iban:
+            return None
+
+        for iban, account in self.entries:
+            if iban == normalized_iban:
+                return account
+
+    def account_matches(self, value: Optional[str]) -> bool:
+        return bool(self.account_for(value))

--- a/tests/test_ec_v1.py
+++ b/tests/test_ec_v1.py
@@ -360,6 +360,20 @@ def test_extract_with_description_patterns(tmp_file_single_transaction, header):
     assert directives[0].postings[1].units is None
 
 
+def test_iban_matcher_ignores_v1_account_number(tmp_file_single_transaction, header):
+    importer = ECImporter(
+        IBAN,
+        "Assets:DKB:EC",
+        iban_matcher=[("DE00000000000000000000", "Assets:DKB:HYSA")],
+    )
+
+    directives = importer.extract(tmp_file_single_transaction)
+
+    assert len(directives) == 2
+    assert len(directives[0].postings) == 1
+    assert directives[0].postings[0].account == "Assets:DKB:EC"
+
+
 def test_extract_with_payee_and_description_patterns(
     tmp_file_single_transaction, header
 ):

--- a/tests/test_ec_v2.py
+++ b/tests/test_ec_v2.py
@@ -51,7 +51,12 @@ def tmp_file_no_transactions(tmp_path, header):
 
     return tmp_file
 
-def tmp_file_single_transaction_base(tmp_path, header, u18: bool = False):
+def tmp_file_single_transaction_base(
+    tmp_path,
+    header,
+    u18: bool = False,
+    counterparty_iban: str = "DE00000000000000000000",
+):
     """
     Fixture for a temporary file with a single transaction
     """
@@ -65,9 +70,15 @@ def tmp_file_single_transaction_base(tmp_path, header, u18: bool = False):
             "Kontostand vom 30.06.2023:"{delimiter}"5.001,01 EUR"
             ""
             {header}
-            "15.06.23"{delimiter}"15.06.23"{delimiter}"Gebucht"{delimiter}"ISSUER"{delimiter}"EDEKA//MUENCHEN/DE"{delimiter}"EDEKA SAGT DANKE"{delimiter}"Ausgang"{delimiter}"DE00000000000000000000"{delimiter}"-8,67"{delimiter}"DE9100112233445566"{delimiter}""{delimiter}"00000000000000000000000000"
+            "15.06.23"{delimiter}"15.06.23"{delimiter}"Gebucht"{delimiter}"ISSUER"{delimiter}"EDEKA//MUENCHEN/DE"{delimiter}"EDEKA SAGT DANKE"{delimiter}"Ausgang"{delimiter}"{counterparty_iban}"{delimiter}"-8,67"{delimiter}"DE9100112233445566"{delimiter}""{delimiter}"00000000000000000000000000"
             """,  # NOQA
-            dict(u18=' u18' if u18 else '', iban=IBAN, header=header.value, delimiter=header.delimiter),
+            dict(
+                u18=' u18' if u18 else '',
+                iban=IBAN,
+                header=header.value,
+                delimiter=header.delimiter,
+                counterparty_iban=counterparty_iban,
+            ),
         ),
         encoding=ENCODING,
     )
@@ -81,6 +92,15 @@ def tmp_file_single_transaction(tmp_path, header):
 @pytest.fixture
 def tmp_file_single_transaction_u18(tmp_path, header):
     return tmp_file_single_transaction_base(tmp_path, header, u18 = True)
+
+
+@pytest.fixture
+def tmp_file_single_transaction_without_iban(tmp_path, header):
+    return tmp_file_single_transaction_base(
+        tmp_path,
+        header,
+        counterparty_iban="",
+    )
 
 @pytest.fixture
 def tmp_file_multiple_transaction(tmp_path, header):
@@ -384,6 +404,44 @@ def test_iban_matcher_requires_exact_match(tmp_file_single_transaction):
     assert len(directives) == 2
     assert len(directives[0].postings) == 1
     assert directives[0].postings[0].account == "Assets:DKB:EC"
+
+
+def test_iban_matcher_uses_first_duplicate_iban(tmp_file_single_transaction):
+    importer = ECImporter(
+        IBAN,
+        "Assets:DKB:EC",
+        iban_matcher=[
+            ("DE00000000000000000000", "Assets:DKB:First"),
+            ("DE00000000000000000000", "Assets:DKB:Second"),
+        ],
+    )
+
+    directives = importer.extract(tmp_file_single_transaction)
+
+    assert len(directives) == 2
+    assert len(directives[0].postings) == 2
+    assert directives[0].postings[1].account == "Assets:DKB:First"
+    assert directives[0].postings[1].units is None
+
+
+def test_empty_transaction_iban_falls_back_to_payee_matcher(
+    tmp_file_single_transaction_without_iban,
+    recwarn,
+):
+    importer = ECImporter(
+        IBAN,
+        "Assets:DKB:EC",
+        payee_patterns=[("EDEKA", "Expenses:Supermarket:EDEKA")],
+        iban_matcher=[("DE00000000000000000000", "Assets:DKB:HYSA")],
+    )
+
+    directives = importer.extract(tmp_file_single_transaction_without_iban)
+
+    assert len(directives) == 2
+    assert len(directives[0].postings) == 2
+    assert directives[0].postings[1].account == "Expenses:Supermarket:EDEKA"
+    assert directives[0].postings[1].units is None
+    assert len(recwarn) == 0
 
 
 def test_iban_matcher_takes_precedence_over_other_matchers(

--- a/tests/test_ec_v2.py
+++ b/tests/test_ec_v2.py
@@ -353,6 +353,65 @@ def test_extract_with_description_patterns(tmp_file_single_transaction):
     assert directives[0].postings[1].units is None
 
 
+def test_extract_with_iban_matcher_normalizes_iban(tmp_file_single_transaction):
+    importer = ECImporter(
+        IBAN,
+        "Assets:DKB:EC",
+        iban_matcher=[("de00 0000 0000 0000 0000 00", "Assets:DKB:HYSA")],
+    )
+
+    directives = importer.extract(tmp_file_single_transaction)
+
+    assert len(directives) == 2
+    assert len(directives[0].postings) == 2
+    assert directives[0].postings[0].account == "Assets:DKB:EC"
+    assert directives[0].postings[0].units.currency == "EUR"
+    assert directives[0].postings[0].units.number == Decimal("-8.67")
+
+    assert directives[0].postings[1].account == "Assets:DKB:HYSA"
+    assert directives[0].postings[1].units is None
+
+
+def test_iban_matcher_requires_exact_match(tmp_file_single_transaction):
+    importer = ECImporter(
+        IBAN,
+        "Assets:DKB:EC",
+        iban_matcher=[("DE00", "Assets:DKB:HYSA")],
+    )
+
+    directives = importer.extract(tmp_file_single_transaction)
+
+    assert len(directives) == 2
+    assert len(directives[0].postings) == 1
+    assert directives[0].postings[0].account == "Assets:DKB:EC"
+
+
+def test_iban_matcher_takes_precedence_over_other_matchers(
+    tmp_file_single_transaction,
+):
+    importer = ECImporter(
+        IBAN,
+        "Assets:DKB:EC",
+        payee_patterns=[("EDEKA", "Expenses:Supermarket:EDEKA")],
+        description_patterns=[("SAGT DANKE", "Expenses:Supermarket:EDEKA")],
+        iban_matcher=[("DE00000000000000000000", "Assets:DKB:HYSA")],
+    )
+
+    with pytest.warns(UserWarning) as user_warnings:
+        directives = importer.extract(tmp_file_single_transaction)
+
+    assert len(directives) == 2
+    assert len(directives[0].postings) == 2
+    assert directives[0].postings[1].account == "Assets:DKB:HYSA"
+    assert directives[0].postings[1].units is None
+
+    assert len(user_warnings) == 1
+    assert user_warnings[0].message.args[0] == (
+        "Line 6 matches iban_matcher, payee_patterns and "
+        "description_patterns. Picking iban_matcher."
+    )
+
+
 def test_extract_with_payee_and_description_patterns(tmp_file_single_transaction):
     importer = ECImporter(
         IBAN,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
+import pytest
 from beancount.core.number import Decimal
 
-from beancount_dkb.helpers import fmt_number_de
+from beancount_dkb.helpers import IBANMatcher, fmt_number_de
 
 
 def test_fmt_number_de():
@@ -9,3 +10,15 @@ def test_fmt_number_de():
     assert fmt_number_de("150") == Decimal(150)
     assert fmt_number_de("15,0") == Decimal(15)
     assert fmt_number_de("1234,0") == Decimal(1234)
+
+
+def test_iban_matcher_ignores_empty_entries():
+    with pytest.warns(UserWarning) as user_warnings:
+        matcher = IBANMatcher([(" \t", "Assets:DKB:Empty")])
+
+    assert matcher.account_for(None) is None
+    assert matcher.account_for("") is None
+    assert len(user_warnings) == 1
+    assert user_warnings[0].message.args[0] == (
+        "Ignoring empty iban_matcher entry for account Assets:DKB:Empty."
+    )


### PR DESCRIPTION
## Summary

This adds an `iban_matcher` option to `ECImporter` for assigning the second posting based on the transaction's counterparty IBAN.

The option uses the same list-of-pairs shape as the existing matchers:

```python
ECImporter(
    "DE99 9999 9999 9999 9999 99",
    "Assets:DKB:EC",
    iban_matcher=[
        ("DE88 8888 8888 8888 8888 88", "Assets:Bank:HYSA"),
    ],
)
```

## Motivation

The existing `payee_patterns` and `description_patterns` work well when a transaction can be identified reliably by text. Some recurring transfers are better identified by the counterparty account.

One case is transfers between a checking account and a HYSA, where the payee may always be the account owner and the narration can vary. The stable signal is the counterparty IBAN: anything coming from or going to that account should map to the same Beancount account.

Another case is recurring service-provider transactions where the payee or description changes over time. For example, a provider may appear under several names such as `mobilcom-debitel ist nun freenet`, `freenet ehemals mobilcom-debitel`, or `freenet DLS GmbH`. Similarly, PayPal transactions may include additional address details in the payee. In those cases, matching the stable counterparty IBAN avoids maintaining a growing set of text patterns for the same logical account.

## Behavior

`iban_matcher` compares IBANs with exact equality after normalizing whitespace and casing. It is intentionally not regex-based, because IBANs are stable identifiers and exact matching avoids accidental partial matches.

The matcher only applies to current EC exports that expose a counterparty `IBAN` column. Legacy V1 exports do not expose that field, so they keep the existing payee/description behavior.

When multiple matchers apply, the IBAN match takes precedence over payee and description matches, because it is the most specific signal.
