### PR TITLE
Fix credit card Saldo vom balance parsing

### DIFF
--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -198,8 +198,11 @@ class CreditImporter(Importer):
                 if amount.startswith("--"):
                     amount = value.value.lstrip("--")
 
+                formatter = (
+                    fmt_number_de if key.startswith("Saldo vom") else fmt_number_en
+                )
                 self._balance_amount = Amount(
-                    Decimal(fmt_number_en(amount.rstrip(" EUR"))), self.currency
+                    Decimal(formatter(amount.split()[0])), self.currency
                 )
                 self._closing_balance_index = value.line_index
                 if key.startswith("Saldo vom"):

--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -198,6 +198,8 @@ class CreditImporter(Importer):
                 if amount.startswith("--"):
                     amount = value.value.lstrip("--")
 
+                # Newer "Saldo vom ..." exports use German decimal separators,
+                # while legacy "Saldo:" balances keep the old en_US format.
                 formatter = (
                     fmt_number_de if key.startswith("Saldo vom") else fmt_number_en
                 )

--- a/tests/test_credit_v2.py
+++ b/tests/test_credit_v2.py
@@ -41,7 +41,7 @@ def tmp_file_no_transactions(tmp_path, header):
             """
             "Karte"{delimiter}"Visa Kreditkarte"{delimiter}"{card_number}"
             ""
-            "Saldo vom 31.01.2023:"{delimiter}"5000.01 EUR"
+            "Saldo vom 31.01.2023:"{delimiter}"5.000,01 EUR"
             ""
             {header}
             """,
@@ -66,7 +66,7 @@ def tmp_file_single_transaction(tmp_path, header):
             """
             "Karte"{delimiter}"Visa Kreditkarte"{delimiter}"{card_number}"
             ""
-            "Saldo vom 31.01.2023:"{delimiter}"5000.01 EUR"
+            "Saldo vom 31.01.2023:"{delimiter}"5.000,01 EUR"
             ""
             {header}
             "15.01.23"{delimiter}"15.01.23"{delimiter}"Gebucht"{delimiter}"REWE Filiale Muenchen"{delimiter}"Im Geschäft"{delimiter}"-10,80 €"{delimiter}""
@@ -117,7 +117,7 @@ def tmp_file_balance_bad_number_of_decimal_places(tmp_path, header):
             """
             "Karte"{delimiter}"Visa Kreditkarte"{delimiter}"{card_number}"
             ""
-            "Saldo vom 31.01.2023:"{delimiter}"5000.001 EUR"
+            "Saldo vom 31.01.2023:"{delimiter}"5000,001 EUR"
             ""
             {header}
             """,
@@ -198,14 +198,32 @@ def test_extract_with_description_patterns(tmp_file_single_transaction):
     assert directives[0].postings[1].units is None
 
 
-def test_comma_separator_in_balance(tmp_file_single_transaction):
+def test_comma_separator_in_balance(tmp_file, header):
+    tmp_file.write_text(
+        _format(
+            """
+            "Karte"{delimiter}"Visa Kreditkarte"{delimiter}"{card_number}"
+            ""
+            "Saldo vom 07.01.2026:"{delimiter}"-37,8 EUR"
+            ""
+            {header}
+            """,
+            dict(
+                card_number=CARD_NUMBER,
+                header=header.value,
+                delimiter=header.delimiter,
+            ),
+        )
+    )
+
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit")
 
-    directives = importer.extract(tmp_file_single_transaction)
+    directives = importer.extract(tmp_file)
 
-    assert len(directives) == 2
-    assert isinstance(directives[1], Balance)
-    assert directives[1].amount == Amount(Decimal("5000.01"), currency="EUR")
+    assert len(directives) == 1
+    assert isinstance(directives[0], Balance)
+    assert directives[0].date == datetime.date(2026, 1, 7)
+    assert directives[0].amount == Amount(Decimal("-37.80"), currency="EUR")
 
 
 def test_decimal_places_in_balance(tmp_file_balance_without_decimal_places):
@@ -225,6 +243,6 @@ def test_bad_number_of_decimal_places_in_balance(
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit")
 
     with pytest.raises(
-        NumberFormatError, match="5000.001 contains unexpected number of decimal places"
+        NumberFormatError, match="5000,001 contains unexpected number of decimal places"
     ):
         importer.extract(tmp_file_balance_bad_number_of_decimal_places)


### PR DESCRIPTION
Fixes #298.

This updates credit card balance metadata parsing for newer DKB CSV exports.

Newer exports use German-formatted `Saldo vom ...` metadata, for example:

```csv
"Saldo vom 07.01.2026:";"-37,8 EUR"
```

The previous code parsed all credit card balance metadata with the en_US formatter, which turns values such as `-26,13 EUR` into `-2613.00 EUR`.

Changes:
- Parse newer `Saldo vom ...` balances with the German number formatter.
- Keep legacy `Saldo:` balances on the existing en_US formatter.
- Update v2 credit card tests to use German-formatted `Saldo vom ...` fixture balances.
- Add a regression test for `-37,8 EUR`.

Verification:
- `poetry run python -m pytest tests/test_credit_v2.py`
- `poetry run python -m pytest tests/test_credit_v1.py tests/test_credit_v2.py`
- Direct sample extraction returns `2026-04-25 -26.13 EUR`.