### PR TITLE
Add option to ignore credit card settlement rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,43 @@ line to extract the transactions and pipe all of them into your Beancount file.
 $ bean-extract /path/to/config.py transaction.csv >> you.beancount
 ```
 
+### Ignoring Credit Card Settlement Transactions
+
+DKB credit card CSV exports may contain settlement transactions such as
+`Ausgleich Kreditkarte`. If these settlements are already imported through the EC
+account, configure the `CreditImporter` to ignore and skip them during import.
+
+#### Beancount 3.x
+
+```python
+from beancount_dkb import CreditImporter
+from beangulp import Ingest
+
+importers = (
+    CreditImporter(
+        "9999 9999 9999 9999",
+        "Assets:DKB:Credit",
+        ignore_credit_card_settlements=True,
+    ),
+)
+
+if __name__ == "__main__":
+    ingest = Ingest(importers)
+    ingest()
+```
+
+#### Beancount 2.x
+
+```python
+CONFIG = [
+    CreditImporter(
+        CARD_NUMBER,
+        'Assets:DKB:Credit',
+        ignore_credit_card_settlements=True,
+    )
+]
+```
+
 ### Transaction Codes as Meta Tags
 
 By default, the ECImporter prepends the transaction code ("Buchungstext") to the

--- a/beancount_dkb/credit.py
+++ b/beancount_dkb/credit.py
@@ -12,6 +12,8 @@ from .exceptions import InvalidFormatError
 from .extractors.credit import V1Extractor, V2Extractor
 from .helpers import AccountMatcher, Meta, fmt_number_de, fmt_number_en
 
+_CREDIT_CARD_SETTLEMENT_DESCRIPTION = "ausgleich kreditkarte"
+
 
 class CreditImporter(Importer):
     def __init__(
@@ -21,11 +23,13 @@ class CreditImporter(Importer):
         currency: Optional[str] = "EUR",
         file_encoding: Optional[str] = None,
         description_patterns: Optional[Sequence] = None,
+        ignore_credit_card_settlements: bool = False,
     ):
         self.card_number = card_number
         self.account_name = account_name
         self.currency = currency
         self.description_matcher = AccountMatcher(description_patterns)
+        self.ignore_credit_card_settlements = ignore_credit_card_settlements
 
         self._v1_extractor = V1Extractor(card_number)
         self._v2_extractor = V2Extractor(card_number)
@@ -135,13 +139,16 @@ class CreditImporter(Importer):
         for line in reader:
             line_index += 1
 
-            meta = data.new_metadata(filepath, line_index)
-
             amount = Amount(fmt_number_de(extractor.get_amount(line)), self.currency)
 
-            date = extractor.get_valuation_date(line)
-
             description = extractor.get_description(line)
+
+            if self._ignore_line(description, amount):
+                continue
+
+            meta = data.new_metadata(filepath, line_index)
+
+            date = extractor.get_valuation_date(line)
 
             postings = [
                 data.Posting(self.account(filepath), amount, None, None, None, None)
@@ -186,6 +193,17 @@ class CreditImporter(Importer):
         )
 
         return entries
+
+    def _ignore_line(self, description: str, amount: Amount) -> bool:
+        if not self.ignore_credit_card_settlements:
+            return False
+
+        normalized_description = " ".join(description.casefold().split())
+
+        return (
+            _CREDIT_CARD_SETTLEMENT_DESCRIPTION in normalized_description
+            and amount.number > Decimal("0")
+        )
 
     def _update_meta(self, meta: Dict[str, str]):
         for key, value in meta.items():

--- a/tests/test_credit_v1.py
+++ b/tests/test_credit_v1.py
@@ -212,6 +212,39 @@ def test_extract_transactions(tmp_file, header):
     assert directives[0].postings[0].units.number == Decimal("-10.80")
 
 
+def test_ignore_credit_card_settlements_skips_positive_settlement(tmp_file, header):
+    tmp_file.write_text(
+        _format(
+            """
+            "Kreditkarte:";"{card_number} Kreditkarte";
+
+            "Von:";"01.01.2022";
+            "Bis:";"31.12.2023";
+            "Saldo:";"5000.01 EUR";
+            "Datum:";"31.12.2023";
+
+            {header}
+            "Ja";"23.11.2022";"22.11.2022";"Ausgleich Kreditkarte gem. Abrechnung v. 22.11.22";"136,52";"";
+            """,  # NOQA
+            dict(card_number=CARD_NUMBER, header=header),
+        ),
+        encoding=ENCODING,
+    )
+
+    importer = CreditImporter(
+        CARD_NUMBER,
+        "Assets:DKB:Credit",
+        ignore_credit_card_settlements=True,
+    )
+
+    directives = importer.extract(tmp_file)
+
+    assert len(directives) == 1
+    assert isinstance(directives[0], Balance)
+    assert directives[0].date == datetime.date(2024, 1, 1)
+    assert directives[0].amount == Amount(Decimal("5000.01"), currency="EUR")
+
+
 def test_extract_sets_timestamps(tmp_file, header):
     tmp_file.write_text(
         _format(

--- a/tests/test_credit_v2.py
+++ b/tests/test_credit_v2.py
@@ -169,6 +169,111 @@ def test_extract_transactions(tmp_file_single_transaction):
     assert directives[0].postings[0].units.number == Decimal("-10.80")
 
 
+def test_credit_card_settlements_are_imported_by_default(tmp_path, header):
+    tmp_file = tmp_path / f"{CARD_NUMBER}.csv"
+    tmp_file.write_text(
+        _format(
+            """
+            "Karte"{delimiter}"Visa Kreditkarte"{delimiter}"{card_number}"
+            ""
+            "Saldo vom 31.12.2025:"{delimiter}"5000.01 EUR"
+            ""
+            {header}
+            "22.12.25"{delimiter}"23.12.25"{delimiter}"Gebucht"{delimiter}"Ausgleich Kreditkarte gem"{delimiter}"Lastschrift"{delimiter}"1.013,47"{delimiter}""
+            """,
+            dict(
+                card_number=CARD_NUMBER, header=header.value, delimiter=header.delimiter
+            ),
+        )
+    )
+
+    importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit")
+
+    directives = importer.extract(tmp_file)
+
+    assert len(directives) == 2
+    assert directives[0].date == datetime.date(2025, 12, 23)
+    assert directives[0].postings[0].account == "Assets:DKB:Credit"
+    assert directives[0].postings[0].units.number == Decimal("1013.47")
+
+
+def test_ignore_credit_card_settlements_skips_positive_settlement(tmp_path, header):
+    tmp_file = tmp_path / f"{CARD_NUMBER}.csv"
+    tmp_file.write_text(
+        _format(
+            """
+            "Karte"{delimiter}"Visa Kreditkarte"{delimiter}"{card_number}"
+            ""
+            "Saldo vom 31.12.2025:"{delimiter}"5000.01 EUR"
+            ""
+            {header}
+            "22.11.24"{delimiter}"23.11.24"{delimiter}"Gebucht"{delimiter}"ausgleich kreditkarte GEM"{delimiter}"Lastschrift"{delimiter}"138,98"{delimiter}""
+            """,
+            dict(
+                card_number=CARD_NUMBER, header=header.value, delimiter=header.delimiter
+            ),
+        )
+    )
+
+    importer = CreditImporter(
+        CARD_NUMBER,
+        "Assets:DKB:Credit",
+        description_patterns=[("Ausgleich Kreditkarte", "Assets:DKB:EC")],
+        ignore_credit_card_settlements=True,
+    )
+
+    directives = importer.extract(tmp_file)
+
+    assert len(directives) == 1
+    assert isinstance(directives[0], Balance)
+    assert directives[0].date == datetime.date(2025, 12, 31)
+    assert directives[0].amount == Amount(Decimal("5000.01"), currency="EUR")
+
+
+@pytest.mark.parametrize(
+    ("amount", "expected_amount"),
+    [
+        ("0,00", Decimal("0.00")),
+        ("-10,80", Decimal("-10.80")),
+    ],
+)
+def test_ignore_credit_card_settlements_keeps_non_positive_transactions(
+    tmp_path, header, amount, expected_amount
+):
+    tmp_file = tmp_path / f"{CARD_NUMBER}.csv"
+    tmp_file.write_text(
+        _format(
+            """
+            "Karte"{delimiter}"Visa Kreditkarte"{delimiter}"{card_number}"
+            ""
+            "Saldo vom 31.01.2023:"{delimiter}"5000.01 EUR"
+            ""
+            {header}
+            "15.01.23"{delimiter}"15.01.23"{delimiter}"Gebucht"{delimiter}"Ausgleich Kreditkarte gem"{delimiter}"Lastschrift"{delimiter}"{amount}"{delimiter}""
+            """,
+            dict(
+                amount=amount,
+                card_number=CARD_NUMBER,
+                header=header.value,
+                delimiter=header.delimiter,
+            ),
+        )
+    )
+
+    importer = CreditImporter(
+        CARD_NUMBER,
+        "Assets:DKB:Credit",
+        ignore_credit_card_settlements=True,
+    )
+
+    directives = importer.extract(tmp_file)
+
+    assert len(directives) == 2
+    assert directives[0].date == datetime.date(2023, 1, 15)
+    assert directives[0].postings[0].account == "Assets:DKB:Credit"
+    assert directives[0].postings[0].units.number == expected_amount
+
+
 def test_emits_closing_balance_directive(tmp_file_single_transaction):
     importer = CreditImporter(CARD_NUMBER, "Assets:DKB:Credit")
 


### PR DESCRIPTION
**Summary**
Adds `ignore_credit_card_settlements` to `CreditImporter` and the Beancount 3 credit importer config.

**Motivation**
DKB credit-card CSVs include monthly settlement rows such as `Ausgleich Kreditkarte gem...`. Users importing both EC and credit-card CSVs may already account for these settlements from the EC side.

**Behaviour**
When enabled, the credit importer skips rows where `Beschreibung` contains `Ausgleich Kreditkarte` case-insensitively and the parsed `Betrag` is strictly positive. Matching rows are skipped before `description_patterns`; zero and negative matching rows are still imported.
