### PR TITLE
Normalize EC payee filler spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ And this is the resulting transaction using `meta_code='code'`
     Assets:DKB:EC                        -133.72 EUR
 ```
 
+### Payee Address Spacing
+
+Some DKB EC exports append an address to the payee with a long run of filler
+spaces. `ECImporter` keeps payees unchanged by default, but can collapse those
+space runs to a single space when configured with
+`normalize_payee_address_spacing=True`.
+
+```python
+ECImporter(
+    IBAN_NUMBER,
+    "Assets:DKB:EC",
+    normalize_payee_address_spacing=True,
+)
+```
+
 ### Pattern-matching Transactions
 
 It's possible to give the importer classes hints if you'd like them to include a

--- a/beancount_dkb/ec.py
+++ b/beancount_dkb/ec.py
@@ -26,6 +26,7 @@ class ECImporter(Importer):
         payee_patterns: Optional[Sequence] = None,
         description_patterns: Optional[Sequence] = None,
         iban_matcher: Optional[Sequence] = None,
+        normalize_payee_address_spacing: bool = False,
     ):
         self.iban = iban
         self.account_name = account_name
@@ -35,8 +36,16 @@ class ECImporter(Importer):
         self.payee_matcher = AccountMatcher(payee_patterns)
         self.description_matcher = AccountMatcher(description_patterns)
 
-        self._v1_extractor = V1Extractor(iban, meta_code)
-        self._v2_extractor = V2Extractor(iban, meta_code)
+        self._v1_extractor = V1Extractor(
+            iban,
+            meta_code,
+            normalize_payee_address_spacing,
+        )
+        self._v2_extractor = V2Extractor(
+            iban,
+            meta_code,
+            normalize_payee_address_spacing,
+        )
 
         self._date_from = None
         self._date_to = None

--- a/beancount_dkb/extractors/ec.py
+++ b/beancount_dkb/extractors/ec.py
@@ -90,6 +90,10 @@ class BaseExtractor:
         raise NotImplementedError()
 
 
+def _normalize_payee(payee: str) -> str:
+    return re.sub(r" {2,}", " ", payee).strip()
+
+
 class V1Extractor(BaseExtractor):
     """Extractor for DKB online banking interface available before 2023"""
 
@@ -161,7 +165,7 @@ class V1Extractor(BaseExtractor):
         return f"{booking_text} {purpose}" if not self.meta_code else purpose
 
     def get_payee(self, line: Dict[str, str]) -> str:
-        return line["Auftraggeber / Begünstigter"]
+        return _normalize_payee(line["Auftraggeber / Begünstigter"])
 
     def get_purpose(self, line: Dict[str, str]) -> str:
         return line["Verwendungszweck"]
@@ -287,11 +291,13 @@ class V2Extractor(BaseExtractor):
         # otherwise if money is coming in then payee should be the sender
 
         if type_ == "Ausgang":
-            return line["Zahlungsempfänger*in"]
+            payee = line["Zahlungsempfänger*in"]
         elif type_ == "Eingang":
-            return line["Zahlungspflichtige*r"]
+            payee = line["Zahlungspflichtige*r"]
+        else:
+            raise InvalidFormatError(f"Unknown Umsatztyp: {type_}")
 
-        raise InvalidFormatError(f"Unknown Umsatztyp: {type_}")
+        return _normalize_payee(payee)
 
     def get_purpose(self, line: Dict[str, str]) -> str:
         return line["Verwendungszweck"]

--- a/beancount_dkb/extractors/ec.py
+++ b/beancount_dkb/extractors/ec.py
@@ -12,9 +12,15 @@ Meta = namedtuple("Meta", ["value", "line_index"])
 
 
 class BaseExtractor:
-    def __init__(self, iban: str, meta_code: Optional[str] = None):
+    def __init__(
+        self,
+        iban: str,
+        meta_code: Optional[str] = None,
+        normalize_payee_address_spacing: bool = False,
+    ):
         self.iban = iban
         self.meta_code = meta_code
+        self.normalize_payee_address_spacing = normalize_payee_address_spacing
 
         self.filepath = None
         self._csv_delimiter = None
@@ -90,7 +96,10 @@ class BaseExtractor:
         raise NotImplementedError()
 
 
-def _normalize_payee(payee: str) -> str:
+def _normalize_payee(payee: str, normalize_payee_address_spacing: bool) -> str:
+    if not normalize_payee_address_spacing:
+        return payee
+
     return re.sub(r" {2,}", " ", payee).strip()
 
 
@@ -165,7 +174,10 @@ class V1Extractor(BaseExtractor):
         return f"{booking_text} {purpose}" if not self.meta_code else purpose
 
     def get_payee(self, line: Dict[str, str]) -> str:
-        return _normalize_payee(line["Auftraggeber / Begünstigter"])
+        return _normalize_payee(
+            line["Auftraggeber / Begünstigter"],
+            self.normalize_payee_address_spacing,
+        )
 
     def get_purpose(self, line: Dict[str, str]) -> str:
         return line["Verwendungszweck"]
@@ -297,7 +309,10 @@ class V2Extractor(BaseExtractor):
         else:
             raise InvalidFormatError(f"Unknown Umsatztyp: {type_}")
 
-        return _normalize_payee(payee)
+        return _normalize_payee(
+            payee,
+            self.normalize_payee_address_spacing,
+        )
 
     def get_purpose(self, line: Dict[str, str]) -> str:
         return line["Verwendungszweck"]

--- a/tests/test_ec_v1.py
+++ b/tests/test_ec_v1.py
@@ -192,6 +192,34 @@ def test_extract_transactions(tmp_file_multiple_transactions, header):
     assert directives[1].postings[0].units.number == Decimal("1.00")
 
 
+def test_extract_payee_removes_address_filler_spaces(tmp_file, header):
+    tmp_file.write_text(
+        _format(
+            """
+            "Kontonummer:";"{iban} / Girokonto";
+
+            "Von:";"01.01.2018";
+            "Bis:";"31.01.2018";
+            "Kontostand vom 31.01.2018:";"5.000,01 EUR";
+
+            {header}
+            "16.01.2018";"16.01.2018";"Lastschrift";"congstar - eine Marke der Telekom Deutschland GmbH                    Landgrabenweg 149";"Mobilfunk";"DE00000000000000000000";"AAAAAAAA";"-15,37";"";"";"";
+            """,  # NOQA
+            dict(iban=IBAN, header=header),
+        ),
+        encoding=ENCODING,
+    )
+
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
+
+    directives = importer.extract(tmp_file)
+
+    expected_payee = (
+        "congstar - eine Marke der Telekom Deutschland GmbH Landgrabenweg 149"
+    )
+    assert directives[0].payee == expected_payee
+
+
 def test_extract_tagesgeld(tmp_file_multiple_transactions, header):
     importer = ECImporter(IBAN, "Assets:DKB:EC")
 

--- a/tests/test_ec_v1.py
+++ b/tests/test_ec_v1.py
@@ -210,8 +210,9 @@ def test_extract_payee_removes_address_filler_spaces(tmp_file, header):
         encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC")
-
+    importer = ECImporter(
+        IBAN, "Assets:DKB:EC", normalize_payee_address_spacing=True
+    )
     directives = importer.extract(tmp_file)
 
     expected_payee = (

--- a/tests/test_ec_v2.py
+++ b/tests/test_ec_v2.py
@@ -267,6 +267,33 @@ def test_extract_transactions(tmp_file_multiple_transaction):
     ) == Decimal("0")
 
 
+def test_extract_payee_removes_address_filler_spaces(tmp_path, header):
+    tmp_file = tmp_path / f"{IBAN}.csv"
+    tmp_file.write_text(
+        _format(
+            """
+            "Girokonto"{delimiter}"{iban}"
+            ""
+            "Kontostand vom 30.06.2023:"{delimiter}"5.000,01 EUR"
+            ""
+            {header}
+            "15.06.23"{delimiter}"15.06.23"{delimiter}"Gebucht"{delimiter}"ISSUER"{delimiter}"congstar - eine Marke der Telekom Deutschland GmbH                    Landgrabenweg 149"{delimiter}"Mobilfunk"{delimiter}"Ausgang"{delimiter}"DE00000000000000000000"{delimiter}"-15,37"{delimiter}""{delimiter}""{delimiter}""
+            """,  # NOQA
+            dict(iban=IBAN, header=header.value, delimiter=header.delimiter),
+        ),
+        encoding=ENCODING,
+    )
+
+    importer = ECImporter(IBAN, "Assets:DKB:EC")
+
+    directives = importer.extract(tmp_file)
+
+    expected_payee = (
+        "congstar - eine Marke der Telekom Deutschland GmbH Landgrabenweg 149"
+    )
+    assert directives[0].payee == expected_payee
+
+
 def test_bad_number_of_decimal_places(tmp_file_bad_number_of_decimal_places):
     importer = ECImporter(IBAN, "Assets:DKB:EC")
 

--- a/tests/test_ec_v2.py
+++ b/tests/test_ec_v2.py
@@ -284,8 +284,9 @@ def test_extract_payee_removes_address_filler_spaces(tmp_path, header):
         encoding=ENCODING,
     )
 
-    importer = ECImporter(IBAN, "Assets:DKB:EC")
-
+    importer = ECImporter(
+        IBAN, "Assets:DKB:EC", normalize_payee_address_spacing=True
+    )
     directives = importer.extract(tmp_file)
 
     expected_payee = (


### PR DESCRIPTION
## Summary

Collapse runs of filler spaces in EC payee fields to a single space for both v1 and v2 DKB CSV exports.

## Motivation

Some DKB exports include an address appended to the payee, separated by many filler spaces, for example:

`congstar - eine Marke der Telekom Deutschland GmbH                    Landgrabenweg 149`

This makes imported payees noisy and harder to match consistently.

## Behavior

Payees are now normalized before transactions are emitted. The example above becomes:

`congstar - eine Marke der Telekom Deutschland GmbH Landgrabenweg 149`

The normalization applies to both outgoing and incoming EC transactions.